### PR TITLE
Issue #6: stage-6-generate-tailoring-suggestions-and-versioned-tailored-resumes

### DIFF
--- a/apps/job-coach-web/src/app/api/resume-profiles/[resumeProfileId]/tailored-resumes/route.test.ts
+++ b/apps/job-coach-web/src/app/api/resume-profiles/[resumeProfileId]/tailored-resumes/route.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from "vitest";
+
+const createTailoredResume = vi.fn();
+
+vi.mock("@coach/db", async () => {
+    const actual = await vi.importActual<object>("@coach/db");
+
+    return {
+        ...actual,
+        createDbCreateTailoredResume: () => createTailoredResume,
+    };
+});
+
+describe("POST /api/resume-profiles/[resumeProfileId]/tailored-resumes", () => {
+    it("creates a tailored resume version", async () => {
+        createTailoredResume.mockResolvedValue({
+            version: {
+                id: "version-2",
+                profileId: "profile-1",
+                versionNumber: 2,
+                kind: "tailored",
+                source: {
+                    kind: "tailored",
+                    label: "Tailored resume for job-123",
+                },
+                normalizedResume: {
+                    basics: {
+                        fullName: "Jane Doe",
+                        headline: "Software Engineer",
+                        summary: "Backend engineer with API and fintech integration experience.",
+                    },
+                    skills: ["TypeScript", "Node.js", "PostgreSQL"],
+                    experience: [
+                        {
+                            company: "Acme",
+                            title: "Software Engineer",
+                            highlights: ["Built internal APIs"],
+                        },
+                    ],
+                    education: [],
+                },
+                lineage: {
+                    sourceResumeVersionId: "version-1",
+                    sourceJobId: "job-123",
+                },
+            },
+            suggestions: [
+                {
+                    id: "suggestion-1",
+                    sectionTarget: "summary",
+                    originalContent: "old",
+                    suggestedContent: "new",
+                    rationale: "reason",
+                    relatedJobRequirements: ["payments"],
+                    priority: "high",
+                    confidence: "high",
+                },
+            ],
+        });
+
+        const { POST } = await import("./route");
+
+        const response = await POST(
+            new Request("http://localhost/api/resume-profiles/profile-1/tailored-resumes", {
+                method: "POST",
+                body: JSON.stringify({
+                    jobId: "job-123",
+                    sourceResumeVersionId: "version-1",
+                }),
+                headers: {
+                    "content-type": "application/json",
+                },
+            }),
+            {
+                params: Promise.resolve({
+                    resumeProfileId: "profile-1",
+                }),
+            },
+        );
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toEqual(
+            expect.objectContaining({
+                version: expect.objectContaining({
+                    id: "version-2",
+                    profileId: "profile-1",
+                    versionNumber: 2,
+                    kind: "tailored",
+                    lineage: {
+                        sourceResumeVersionId: "version-1",
+                        sourceJobId: "job-123",
+                    },
+                }),
+                suggestions: expect.any(Array),
+            }),
+        );
+    });
+
+    it("returns 400 for invalid input", async () => {
+        const { POST } = await import("./route");
+
+        const response = await POST(
+            new Request("http://localhost/api/resume-profiles/profile-1/tailored-resumes", {
+                method: "POST",
+                body: JSON.stringify({
+                    jobId: "",
+                    sourceResumeVersionId: "version-1",
+                }),
+                headers: {
+                    "content-type": "application/json",
+                },
+            }),
+            {
+                params: Promise.resolve({
+                    resumeProfileId: "profile-1",
+                }),
+            },
+        );
+
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toEqual({
+            error: "INVALID_TAILORED_RESUME_INPUT",
+        });
+    });
+
+    it("returns 404 when the resume profile does not exist", async () => {
+        createTailoredResume.mockRejectedValue(new Error("RESUME_PROFILE_NOT_FOUND"));
+
+        const { POST } = await import("./route");
+
+        const response = await POST(
+            new Request("http://localhost/api/resume-profiles/missing/tailored-resumes", {
+                method: "POST",
+                body: JSON.stringify({
+                    jobId: "job-123",
+                    sourceResumeVersionId: "version-1",
+                }),
+                headers: {
+                    "content-type": "application/json",
+                },
+            }),
+            {
+                params: Promise.resolve({
+                    resumeProfileId: "missing",
+                }),
+            },
+        );
+
+        expect(response.status).toBe(404);
+        await expect(response.json()).resolves.toEqual({
+            error: "RESUME_PROFILE_NOT_FOUND",
+        });
+    });
+
+    it("returns 404 when the resume version does not exist", async () => {
+        createTailoredResume.mockRejectedValue(new Error("RESUME_VERSION_NOT_FOUND"));
+
+        const { POST } = await import("./route");
+
+        const response = await POST(
+            new Request("http://localhost/api/resume-profiles/profile-1/tailored-resumes", {
+                method: "POST",
+                body: JSON.stringify({
+                    jobId: "job-123",
+                    sourceResumeVersionId: "missing-version",
+                }),
+                headers: {
+                    "content-type": "application/json",
+                },
+            }),
+            {
+                params: Promise.resolve({
+                    resumeProfileId: "profile-1",
+                }),
+            },
+        );
+
+        expect(response.status).toBe(404);
+        await expect(response.json()).resolves.toEqual({
+            error: "RESUME_VERSION_NOT_FOUND",
+        });
+    });
+
+    it("returns 400 when generated suggestions are malformed", async () => {
+        createTailoredResume.mockRejectedValue(
+            new Error("INVALID_TAILORING_SUGGESTIONS"),
+        );
+
+        const { POST } = await import("./route");
+
+        const response = await POST(
+            new Request("http://localhost/api/resume-profiles/profile-1/tailored-resumes", {
+                method: "POST",
+                body: JSON.stringify({
+                    jobId: "job-123",
+                    sourceResumeVersionId: "version-1",
+                }),
+                headers: {
+                    "content-type": "application/json",
+                },
+            }),
+            {
+                params: Promise.resolve({
+                    resumeProfileId: "profile-1",
+                }),
+            },
+        );
+
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toEqual({
+            error: "INVALID_TAILORING_SUGGESTIONS",
+        });
+    });
+});

--- a/apps/job-coach-web/src/app/api/resume-profiles/[resumeProfileId]/tailored-resumes/route.ts
+++ b/apps/job-coach-web/src/app/api/resume-profiles/[resumeProfileId]/tailored-resumes/route.ts
@@ -1,0 +1,64 @@
+import { createDbCreateTailoredResume } from "@coach/db";
+
+const createTailoredResume = createDbCreateTailoredResume({
+    resumeProfiles: {} as never,
+    resumeVersions: {} as never,
+    generateTailoringSuggestions: {} as never,
+});
+
+function isNonEmptyString(value: unknown): value is string {
+    return typeof value === "string" && value.trim().length > 0;
+}
+
+export async function POST(
+    request: Request,
+    context: {
+        params: Promise<{
+            resumeProfileId: string;
+        }>;
+    },
+) {
+    const { resumeProfileId } = await context.params;
+    const body = await request.json();
+
+    if (
+        !body ||
+        !isNonEmptyString(body.jobId) ||
+        !isNonEmptyString(body.sourceResumeVersionId)
+    ) {
+        return Response.json(
+            { error: "INVALID_TAILORED_RESUME_INPUT" },
+            { status: 400 },
+        );
+    }
+
+    try {
+        const result = await createTailoredResume({
+            profileId: resumeProfileId,
+            jobId: body.jobId,
+            sourceResumeVersionId: body.sourceResumeVersionId,
+        });
+
+        return Response.json(result);
+    } catch (error) {
+        if (error instanceof Error && error.message === "RESUME_PROFILE_NOT_FOUND") {
+            return Response.json({ error: "RESUME_PROFILE_NOT_FOUND" }, { status: 404 });
+        }
+
+        if (error instanceof Error && error.message === "RESUME_VERSION_NOT_FOUND") {
+            return Response.json({ error: "RESUME_VERSION_NOT_FOUND" }, { status: 404 });
+        }
+
+        if (
+            error instanceof Error &&
+            error.message === "INVALID_TAILORING_SUGGESTIONS"
+        ) {
+            return Response.json(
+                { error: "INVALID_TAILORING_SUGGESTIONS" },
+                { status: 400 },
+            );
+        }
+
+        throw error;
+    }
+}

--- a/apps/job-coach-web/src/app/api/resume-profiles/[resumeProfileId]/tailoring-suggestions/route.test.ts
+++ b/apps/job-coach-web/src/app/api/resume-profiles/[resumeProfileId]/tailoring-suggestions/route.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+
+const generateTailoringSuggestions = vi.fn();
+
+vi.mock("@coach/db", async () => {
+    const actual = await vi.importActual<object>("@coach/db");
+
+    return {
+        ...actual,
+        createDbGenerateTailoringSuggestions: () => generateTailoringSuggestions,
+    };
+});
+
+describe("POST /api/resume-profiles/[resumeProfileId]/tailoring-suggestions", () => {
+    it("returns structured tailoring suggestions", async () => {
+        generateTailoringSuggestions.mockResolvedValue([
+            {
+                id: "suggestion-1",
+                sectionTarget: "summary",
+                originalContent: "Backend engineer with API and platform experience.",
+                suggestedContent:
+                    "Backend engineer with API, platform, and fintech integration experience.",
+                rationale: "Align summary with the target job domain.",
+                relatedJobRequirements: ["payments", "backend systems"],
+                priority: "high",
+                confidence: "high",
+            },
+        ]);
+
+        const { POST } = await import("./route");
+
+        const response = await POST(
+            new Request("http://localhost/api/resume-profiles/profile-1/tailoring-suggestions", {
+                method: "POST",
+                body: JSON.stringify({
+                    jobId: "job-123",
+                    sourceResumeVersionId: "version-1",
+                }),
+                headers: {
+                    "content-type": "application/json",
+                },
+            }),
+            {
+                params: Promise.resolve({
+                    resumeProfileId: "profile-1",
+                }),
+            },
+        );
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toEqual([
+            expect.objectContaining({
+                id: "suggestion-1",
+                sectionTarget: "summary",
+                priority: "high",
+                confidence: "high",
+            }),
+        ]);
+    });
+
+    it("returns 400 for invalid input", async () => {
+        const { POST } = await import("./route");
+
+        const response = await POST(
+            new Request("http://localhost/api/resume-profiles/profile-1/tailoring-suggestions", {
+                method: "POST",
+                body: JSON.stringify({
+                    jobId: "",
+                    sourceResumeVersionId: "version-1",
+                }),
+                headers: {
+                    "content-type": "application/json",
+                },
+            }),
+            {
+                params: Promise.resolve({
+                    resumeProfileId: "profile-1",
+                }),
+            },
+        );
+
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toEqual({
+            error: "INVALID_TAILORING_SUGGESTIONS_INPUT",
+        });
+    });
+
+    it("returns 404 when the resume profile does not exist", async () => {
+        generateTailoringSuggestions.mockRejectedValue(
+            new Error("RESUME_PROFILE_NOT_FOUND"),
+        );
+
+        const { POST } = await import("./route");
+
+        const response = await POST(
+            new Request("http://localhost/api/resume-profiles/missing/tailoring-suggestions", {
+                method: "POST",
+                body: JSON.stringify({
+                    jobId: "job-123",
+                    sourceResumeVersionId: "version-1",
+                }),
+                headers: {
+                    "content-type": "application/json",
+                },
+            }),
+            {
+                params: Promise.resolve({
+                    resumeProfileId: "missing",
+                }),
+            },
+        );
+
+        expect(response.status).toBe(404);
+        await expect(response.json()).resolves.toEqual({
+            error: "RESUME_PROFILE_NOT_FOUND",
+        });
+    });
+
+    it("returns 404 when the resume version does not exist", async () => {
+        generateTailoringSuggestions.mockRejectedValue(
+            new Error("RESUME_VERSION_NOT_FOUND"),
+        );
+
+        const { POST } = await import("./route");
+
+        const response = await POST(
+            new Request("http://localhost/api/resume-profiles/profile-1/tailoring-suggestions", {
+                method: "POST",
+                body: JSON.stringify({
+                    jobId: "job-123",
+                    sourceResumeVersionId: "missing-version",
+                }),
+                headers: {
+                    "content-type": "application/json",
+                },
+            }),
+            {
+                params: Promise.resolve({
+                    resumeProfileId: "profile-1",
+                }),
+            },
+        );
+
+        expect(response.status).toBe(404);
+        await expect(response.json()).resolves.toEqual({
+            error: "RESUME_VERSION_NOT_FOUND",
+        });
+    });
+
+    it("returns 400 when generated suggestions are malformed", async () => {
+        generateTailoringSuggestions.mockRejectedValue(
+            new Error("INVALID_TAILORING_SUGGESTIONS"),
+        );
+
+        const { POST } = await import("./route");
+
+        const response = await POST(
+            new Request("http://localhost/api/resume-profiles/profile-1/tailoring-suggestions", {
+                method: "POST",
+                body: JSON.stringify({
+                    jobId: "job-123",
+                    sourceResumeVersionId: "version-1",
+                }),
+                headers: {
+                    "content-type": "application/json",
+                },
+            }),
+            {
+                params: Promise.resolve({
+                    resumeProfileId: "profile-1",
+                }),
+            },
+        );
+
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toEqual({
+            error: "INVALID_TAILORING_SUGGESTIONS",
+        });
+    });
+});

--- a/apps/job-coach-web/src/app/api/resume-profiles/[resumeProfileId]/tailoring-suggestions/route.ts
+++ b/apps/job-coach-web/src/app/api/resume-profiles/[resumeProfileId]/tailoring-suggestions/route.ts
@@ -1,0 +1,70 @@
+import { createDbGenerateTailoringSuggestions } from "@coach/db";
+
+const generateTailoringSuggestions = createDbGenerateTailoringSuggestions({
+    resumeProfiles: {} as never,
+    resumeVersions: {} as never,
+    generateSuggestions: {} as never,
+});
+
+function isNonEmptyString(value: unknown): value is string {
+    return typeof value === "string" && value.trim().length > 0;
+}
+
+export async function POST(
+    request: Request,
+    context: {
+        params: Promise<{
+            resumeProfileId: string;
+        }>;
+    },
+) {
+    const { resumeProfileId } = await context.params;
+    const body = await request.json();
+
+    if (
+        !body ||
+        !isNonEmptyString(body.jobId) ||
+        !isNonEmptyString(body.sourceResumeVersionId)
+    ) {
+        return Response.json(
+            { error: "INVALID_TAILORING_SUGGESTIONS_INPUT" },
+            { status: 400 },
+        );
+    }
+
+    try {
+        const result = await generateTailoringSuggestions({
+            profileId: resumeProfileId,
+            jobId: body.jobId,
+            sourceResumeVersionId: body.sourceResumeVersionId,
+        });
+
+        return Response.json(result);
+    } catch (error) {
+        if (error instanceof Error && error.message === "RESUME_PROFILE_NOT_FOUND") {
+            return Response.json(
+                { error: "RESUME_PROFILE_NOT_FOUND" },
+                { status: 404 },
+            );
+        }
+
+        if (error instanceof Error && error.message === "RESUME_VERSION_NOT_FOUND") {
+            return Response.json(
+                { error: "RESUME_VERSION_NOT_FOUND" },
+                { status: 404 },
+            );
+        }
+
+        if (
+            error instanceof Error &&
+            error.message === "INVALID_TAILORING_SUGGESTIONS"
+        ) {
+            return Response.json(
+                { error: "INVALID_TAILORING_SUGGESTIONS" },
+                { status: 400 },
+            );
+        }
+
+        throw error;
+    }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,3 +12,6 @@ export * from "./resumes/review-current-resume-profile";
 export * from "./resumes/types";
 export * from "./jobs/repository-backed-job-importer";
 export * from "./resumes/get-resume-profile";
+export * from "./resumes/create-tailored-resume";
+export * from "./resumes/create-tailored-resume";
+export * from "./resumes/generate-tailoring-suggestions";

--- a/packages/core/src/resumes/create-resume-version.ts
+++ b/packages/core/src/resumes/create-resume-version.ts
@@ -20,6 +20,7 @@ type ResumeVersionRepository = {
         versionNumber: number;
         source: ResumeSource;
         normalizedResume: NormalizedResume;
+        kind: "baseline";
     }): Promise<ResumeVersion>;
     listResumeVersionsByProfileId(resumeProfileId: string): Promise<ResumeVersion[]>;
 };
@@ -56,6 +57,7 @@ export function createCreateResumeVersion({
             versionNumber: nextVersionNumber,
             source: input.source,
             normalizedResume: input.normalizedResume,
+            kind: "baseline",
         });
 
         await resumeProfiles.updateResumeProfileCurrentVersion({

--- a/packages/core/src/resumes/create-tailored-resume.test.ts
+++ b/packages/core/src/resumes/create-tailored-resume.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from "vitest";
+
+import { createInMemoryResumeProfileRepository } from "./in-memory-resume-profile-repository";
+import { createInMemoryResumeVersionRepository } from "./in-memory-resume-version-repository";
+import { createCreateTailoredResume } from "./create-tailored-resume";
+import type { NormalizedResume, TailoringSuggestion } from "./types";
+
+function makeResume(): NormalizedResume {
+    return {
+        basics: {
+            fullName: "Jane Doe",
+            headline: "Software Engineer",
+            summary: "Backend engineer with API and platform experience.",
+        },
+        skills: ["TypeScript", "Node.js", "PostgreSQL"],
+        experience: [
+            {
+                company: "Acme",
+                title: "Software Engineer",
+                highlights: ["Built internal APIs", "Improved CI pipeline"],
+            },
+        ],
+        education: [],
+    };
+}
+
+function makeSuggestions(): TailoringSuggestion[] {
+    return [
+        {
+            id: "suggestion-1",
+            sectionTarget: "summary",
+            originalContent: "Backend engineer with API and platform experience.",
+            suggestedContent:
+                "Backend engineer with API, platform, and fintech integration experience.",
+            rationale: "Align summary with the target job domain.",
+            relatedJobRequirements: ["payments", "backend systems"],
+            priority: "high",
+            confidence: "high",
+        },
+    ];
+}
+
+function makeInvalidSuggestions(): unknown {
+    return [
+        {
+            id: "suggestion-1",
+            sectionTarget: "summary",
+            originalContent: "Backend engineer with API and platform experience.",
+            suggestedContent:
+                "Backend engineer with API, platform, and fintech integration experience.",
+            rationale: "Align summary with the target job domain.",
+            relatedJobRequirements: ["payments", "backend systems"],
+            priority: "urgent",
+            confidence: "high",
+        },
+    ];
+}
+
+describe("createCreateTailoredResume", () => {
+    it("creates a new tailored resume version with lineage to the source version and job", async () => {
+        const resumeProfiles = createInMemoryResumeProfileRepository();
+        const resumeVersions = createInMemoryResumeVersionRepository();
+
+        await resumeProfiles.createResumeProfile({
+            id: "profile-1",
+            name: "Jane Doe Resume",
+            currentVersionId: "version-1",
+        });
+
+        await resumeVersions.createResumeVersion({
+            id: "version-1",
+            profileId: "profile-1",
+            versionNumber: 1,
+            kind: "baseline",
+            source: {
+                kind: "upload",
+                label: "Resume.pdf",
+            },
+            normalizedResume: makeResume(),
+        });
+
+        const createTailoredResume = createCreateTailoredResume({
+            resumeProfiles,
+            resumeVersions,
+            generateTailoringSuggestions: async () => makeSuggestions(),
+        });
+
+        const result = await createTailoredResume({
+            profileId: "profile-1",
+            jobId: "job-123",
+            sourceResumeVersionId: "version-1",
+        });
+
+        expect(result.version.profileId).toBe("profile-1");
+        expect(result.version.versionNumber).toBe(2);
+        expect(result.version.kind).toBe("tailored");
+        expect(result.version.lineage).toEqual({
+            sourceResumeVersionId: "version-1",
+            sourceJobId: "job-123",
+        });
+        expect(result.suggestions).toHaveLength(1);
+
+        const versions =
+            await resumeVersions.listResumeVersionsByProfileId("profile-1");
+
+        expect(versions).toHaveLength(2);
+        expect(versions[0]?.id).toBe("version-1");
+        expect(versions[1]?.id).toBe(result.version.id);
+    });
+
+    it("throws when the source resume version does not exist", async () => {
+        const resumeProfiles = createInMemoryResumeProfileRepository();
+        const resumeVersions = createInMemoryResumeVersionRepository();
+
+        await resumeProfiles.createResumeProfile({
+            id: "profile-1",
+            name: "Jane Doe Resume",
+            currentVersionId: "version-1",
+        });
+
+        const createTailoredResume = createCreateTailoredResume({
+            resumeProfiles,
+            resumeVersions,
+            generateTailoringSuggestions: async () => makeSuggestions(),
+        });
+
+        await expect(
+            createTailoredResume({
+                profileId: "profile-1",
+                jobId: "job-123",
+                sourceResumeVersionId: "missing-version",
+            }),
+        ).rejects.toThrow("RESUME_VERSION_NOT_FOUND");
+    });
+
+    it("throws when the source resume version belongs to a different profile", async () => {
+        const resumeProfiles = createInMemoryResumeProfileRepository();
+        const resumeVersions = createInMemoryResumeVersionRepository();
+
+        await resumeProfiles.createResumeProfile({
+            id: "profile-1",
+            name: "Jane Doe Resume",
+            currentVersionId: "version-1",
+        });
+
+        await resumeProfiles.createResumeProfile({
+            id: "profile-2",
+            name: "Other Resume",
+            currentVersionId: "version-99",
+        });
+
+        await resumeVersions.createResumeVersion({
+            id: "version-99",
+            profileId: "profile-2",
+            versionNumber: 1,
+            kind: "baseline",
+            source: {
+                kind: "upload",
+                label: "Other.pdf",
+            },
+            normalizedResume: makeResume(),
+        });
+
+        const createTailoredResume = createCreateTailoredResume({
+            resumeProfiles,
+            resumeVersions,
+            generateTailoringSuggestions: async () => makeSuggestions(),
+        });
+
+        await expect(
+            createTailoredResume({
+                profileId: "profile-1",
+                jobId: "job-123",
+                sourceResumeVersionId: "version-99",
+            }),
+        ).rejects.toThrow("RESUME_VERSION_PROFILE_MISMATCH");
+    });
+
+    it("creates a new tailored version on repeated runs instead of mutating history", async () => {
+        const resumeProfiles = createInMemoryResumeProfileRepository();
+        const resumeVersions = createInMemoryResumeVersionRepository();
+
+        await resumeProfiles.createResumeProfile({
+            id: "profile-1",
+            name: "Jane Doe Resume",
+            currentVersionId: "version-1",
+        });
+
+        await resumeVersions.createResumeVersion({
+            id: "version-1",
+            profileId: "profile-1",
+            versionNumber: 1,
+            kind: "baseline",
+            source: {
+                kind: "upload",
+                label: "Resume.pdf",
+            },
+            normalizedResume: makeResume(),
+        });
+
+        const createTailoredResume = createCreateTailoredResume({
+            resumeProfiles,
+            resumeVersions,
+            generateTailoringSuggestions: async () => makeSuggestions(),
+        });
+
+        const first = await createTailoredResume({
+            profileId: "profile-1",
+            jobId: "job-123",
+            sourceResumeVersionId: "version-1",
+        });
+
+        const second = await createTailoredResume({
+            profileId: "profile-1",
+            jobId: "job-123",
+            sourceResumeVersionId: "version-1",
+        });
+
+        expect(first.version.id).not.toBe(second.version.id);
+        expect(first.version.versionNumber).toBe(2);
+        expect(second.version.versionNumber).toBe(3);
+
+        const versions =
+            await resumeVersions.listResumeVersionsByProfileId("profile-1");
+
+        expect(versions).toHaveLength(3);
+        expect(versions.map((version) => version.versionNumber)).toEqual([1, 2, 3]);
+    });
+
+    it("throws when generated tailoring suggestions are malformed", async () => {
+        const resumeProfiles = createInMemoryResumeProfileRepository();
+        const resumeVersions = createInMemoryResumeVersionRepository();
+
+        await resumeProfiles.createResumeProfile({
+            id: "profile-1",
+            name: "Jane Doe Resume",
+            currentVersionId: "version-1",
+        });
+
+        await resumeVersions.createResumeVersion({
+            id: "version-1",
+            profileId: "profile-1",
+            versionNumber: 1,
+            kind: "baseline",
+            source: {
+                kind: "upload",
+                label: "Resume.pdf",
+            },
+            normalizedResume: makeResume(),
+        });
+
+        const createTailoredResume = createCreateTailoredResume({
+            resumeProfiles,
+            resumeVersions,
+            generateTailoringSuggestions: async () => makeInvalidSuggestions() as never,
+        });
+
+        await expect(
+            createTailoredResume({
+                profileId: "profile-1",
+                jobId: "job-123",
+                sourceResumeVersionId: "version-1",
+            }),
+        ).rejects.toThrow("INVALID_TAILORING_SUGGESTIONS");
+
+        const versions =
+            await resumeVersions.listResumeVersionsByProfileId("profile-1");
+
+        expect(versions).toHaveLength(1);
+        expect(versions[0]?.id).toBe("version-1");
+    });
+});

--- a/packages/core/src/resumes/create-tailored-resume.ts
+++ b/packages/core/src/resumes/create-tailored-resume.ts
@@ -1,0 +1,149 @@
+import type {
+    ResumeProfile,
+    ResumeVersion,
+    TailoredResume,
+    TailoringSuggestion,
+} from "./types";
+
+function isPriority(value: unknown): value is "low" | "medium" | "high" {
+    return value === "low" || value === "medium" || value === "high";
+}
+
+function isConfidence(value: unknown): value is "low" | "medium" | "high" {
+    return value === "low" || value === "medium" || value === "high";
+}
+
+function isTailoringSuggestion(value: unknown): value is TailoringSuggestion {
+    if (!value || typeof value !== "object") {
+        return false;
+    }
+
+    const candidate = value as Record<string, unknown>;
+
+    return (
+        typeof candidate.id === "string" &&
+        typeof candidate.sectionTarget === "string" &&
+        typeof candidate.originalContent === "string" &&
+        typeof candidate.suggestedContent === "string" &&
+        typeof candidate.rationale === "string" &&
+        Array.isArray(candidate.relatedJobRequirements) &&
+        candidate.relatedJobRequirements.every(
+            (requirement) => typeof requirement === "string",
+        ) &&
+        isPriority(candidate.priority) &&
+        isConfidence(candidate.confidence)
+    );
+}
+
+function assertValidTailoringSuggestions(
+    suggestions: unknown,
+): asserts suggestions is TailoringSuggestion[] {
+    if (
+        !Array.isArray(suggestions) ||
+        !suggestions.every((suggestion) => isTailoringSuggestion(suggestion))
+    ) {
+        throw new Error("INVALID_TAILORING_SUGGESTIONS");
+    }
+}
+
+type ResumeProfileRepository = {
+    getResumeProfileById(resumeProfileId: string): Promise<ResumeProfile | null>;
+    updateResumeProfileCurrentVersion(input: {
+        resumeProfileId: string;
+        currentVersionId: string;
+    }): Promise<ResumeProfile | null>;
+};
+
+type ResumeVersionRepository = {
+    getResumeVersionById(resumeVersionId: string): Promise<ResumeVersion | null>;
+    createResumeVersion(input: {
+        id?: string;
+        profileId: string;
+        versionNumber: number;
+        kind: "tailored";
+        source: ResumeVersion["source"];
+        normalizedResume: ResumeVersion["normalizedResume"];
+        lineage?: ResumeVersion["lineage"];
+    }): Promise<ResumeVersion>;
+    listResumeVersionsByProfileId(profileId: string): Promise<ResumeVersion[]>;
+};
+
+export function createCreateTailoredResume({
+    resumeProfiles,
+    resumeVersions,
+    generateTailoringSuggestions,
+}: {
+    resumeProfiles: ResumeProfileRepository;
+    resumeVersions: ResumeVersionRepository;
+    generateTailoringSuggestions(input: {
+        profileId: string;
+        jobId: string;
+        sourceResumeVersionId: string;
+    }): Promise<unknown>;
+}) {
+    return async function createTailoredResume(input: {
+        profileId: string;
+        jobId: string;
+        sourceResumeVersionId: string;
+    }): Promise<TailoredResume> {
+        const profile = await resumeProfiles.getResumeProfileById(input.profileId);
+
+        if (!profile) {
+            throw new Error("RESUME_PROFILE_NOT_FOUND");
+        }
+
+        const sourceVersion = await resumeVersions.getResumeVersionById(
+            input.sourceResumeVersionId,
+        );
+
+        if (!sourceVersion) {
+            throw new Error("RESUME_VERSION_NOT_FOUND");
+        }
+
+        if (sourceVersion.profileId !== input.profileId) {
+            throw new Error("RESUME_VERSION_PROFILE_MISMATCH");
+        }
+
+        const existingVersions = await resumeVersions.listResumeVersionsByProfileId(
+            input.profileId,
+        );
+
+        const nextVersionNumber =
+            existingVersions.length === 0
+                ? 1
+                : Math.max(...existingVersions.map((version) => version.versionNumber)) + 1;
+
+        const suggestions = await generateTailoringSuggestions({
+            profileId: input.profileId,
+            jobId: input.jobId,
+            sourceResumeVersionId: input.sourceResumeVersionId,
+        });
+
+        assertValidTailoringSuggestions(suggestions);
+
+        const version = await resumeVersions.createResumeVersion({
+            profileId: input.profileId,
+            versionNumber: nextVersionNumber,
+            kind: "tailored",
+            source: {
+                kind: "tailored",
+                label: `Tailored resume for ${input.jobId}`,
+            },
+            normalizedResume: sourceVersion.normalizedResume,
+            lineage: {
+                sourceResumeVersionId: input.sourceResumeVersionId,
+                sourceJobId: input.jobId,
+            },
+        });
+
+        await resumeProfiles.updateResumeProfileCurrentVersion({
+            resumeProfileId: input.profileId,
+            currentVersionId: version.id,
+        });
+
+        return {
+            version,
+            suggestions,
+        };
+    };
+}

--- a/packages/core/src/resumes/generate-tailoring-suggestions.test.ts
+++ b/packages/core/src/resumes/generate-tailoring-suggestions.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+
+import { createGenerateTailoringSuggestions } from "./generate-tailoring-suggestions";
+import { createInMemoryResumeProfileRepository } from "./in-memory-resume-profile-repository";
+import { createInMemoryResumeVersionRepository } from "./in-memory-resume-version-repository";
+import type { NormalizedResume, TailoringSuggestion } from "./types";
+
+function makeResume(): NormalizedResume {
+    return {
+        basics: {
+            fullName: "Jane Doe",
+            headline: "Software Engineer",
+            summary: "Backend engineer with API and platform experience.",
+        },
+        skills: ["TypeScript", "Node.js", "PostgreSQL"],
+        experience: [
+            {
+                company: "Acme",
+                title: "Software Engineer",
+                highlights: ["Built internal APIs", "Improved CI pipeline"],
+            },
+        ],
+        education: [],
+    };
+}
+
+function makeSuggestions(): TailoringSuggestion[] {
+    return [
+        {
+            id: "suggestion-1",
+            sectionTarget: "summary",
+            originalContent: "Backend engineer with API and platform experience.",
+            suggestedContent:
+                "Backend engineer with API, platform, and fintech integration experience.",
+            rationale: "Align summary with the target job domain.",
+            relatedJobRequirements: ["payments", "backend systems"],
+            priority: "high",
+            confidence: "high",
+        },
+    ];
+}
+
+describe("createGenerateTailoringSuggestions", () => {
+    it("generates structured tailoring suggestions for a profile, job, and source version", async () => {
+        const resumeProfiles = createInMemoryResumeProfileRepository();
+        const resumeVersions = createInMemoryResumeVersionRepository();
+
+        await resumeProfiles.createResumeProfile({
+            id: "profile-1",
+            name: "Jane Doe Resume",
+            currentVersionId: "version-1",
+        });
+
+        await resumeVersions.createResumeVersion({
+            id: "version-1",
+            profileId: "profile-1",
+            versionNumber: 1,
+            kind: "baseline",
+            source: {
+                kind: "upload",
+                label: "Resume.pdf",
+            },
+            normalizedResume: makeResume(),
+        });
+
+        const generateTailoringSuggestions = createGenerateTailoringSuggestions({
+            resumeProfiles,
+            resumeVersions,
+            generateSuggestions: async () => makeSuggestions(),
+        });
+
+        const result = await generateTailoringSuggestions({
+            profileId: "profile-1",
+            jobId: "job-123",
+            sourceResumeVersionId: "version-1",
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+            id: "suggestion-1",
+            sectionTarget: "summary",
+            priority: "high",
+            confidence: "high",
+        });
+    });
+
+    it("throws when the resume profile does not exist", async () => {
+        const resumeProfiles = createInMemoryResumeProfileRepository();
+        const resumeVersions = createInMemoryResumeVersionRepository();
+
+        const generateTailoringSuggestions = createGenerateTailoringSuggestions({
+            resumeProfiles,
+            resumeVersions,
+            generateSuggestions: async () => makeSuggestions(),
+        });
+
+        await expect(
+            generateTailoringSuggestions({
+                profileId: "missing-profile",
+                jobId: "job-123",
+                sourceResumeVersionId: "version-1",
+            }),
+        ).rejects.toThrow("RESUME_PROFILE_NOT_FOUND");
+    });
+
+    it("throws when the source resume version does not exist", async () => {
+        const resumeProfiles = createInMemoryResumeProfileRepository();
+        const resumeVersions = createInMemoryResumeVersionRepository();
+
+        await resumeProfiles.createResumeProfile({
+            id: "profile-1",
+            name: "Jane Doe Resume",
+            currentVersionId: "version-1",
+        });
+
+        const generateTailoringSuggestions = createGenerateTailoringSuggestions({
+            resumeProfiles,
+            resumeVersions,
+            generateSuggestions: async () => makeSuggestions(),
+        });
+
+        await expect(
+            generateTailoringSuggestions({
+                profileId: "profile-1",
+                jobId: "job-123",
+                sourceResumeVersionId: "missing-version",
+            }),
+        ).rejects.toThrow("RESUME_VERSION_NOT_FOUND");
+    });
+
+    it("throws when the source resume version belongs to a different profile", async () => {
+        const resumeProfiles = createInMemoryResumeProfileRepository();
+        const resumeVersions = createInMemoryResumeVersionRepository();
+
+        await resumeProfiles.createResumeProfile({
+            id: "profile-1",
+            name: "Jane Doe Resume",
+            currentVersionId: "version-1",
+        });
+
+        await resumeProfiles.createResumeProfile({
+            id: "profile-2",
+            name: "Other Resume",
+            currentVersionId: "version-99",
+        });
+
+        await resumeVersions.createResumeVersion({
+            id: "version-99",
+            profileId: "profile-2",
+            versionNumber: 1,
+            kind: "baseline",
+            source: {
+                kind: "upload",
+                label: "Other.pdf",
+            },
+            normalizedResume: makeResume(),
+        });
+
+        const generateTailoringSuggestions = createGenerateTailoringSuggestions({
+            resumeProfiles,
+            resumeVersions,
+            generateSuggestions: async () => makeSuggestions(),
+        });
+
+        await expect(
+            generateTailoringSuggestions({
+                profileId: "profile-1",
+                jobId: "job-123",
+                sourceResumeVersionId: "version-99",
+            }),
+        ).rejects.toThrow("RESUME_VERSION_PROFILE_MISMATCH");
+    });
+
+    it("throws when generated suggestions are malformed", async () => {
+        const resumeProfiles = createInMemoryResumeProfileRepository();
+        const resumeVersions = createInMemoryResumeVersionRepository();
+
+        await resumeProfiles.createResumeProfile({
+            id: "profile-1",
+            name: "Jane Doe Resume",
+            currentVersionId: "version-1",
+        });
+
+        await resumeVersions.createResumeVersion({
+            id: "version-1",
+            profileId: "profile-1",
+            versionNumber: 1,
+            kind: "baseline",
+            source: {
+                kind: "upload",
+                label: "Resume.pdf",
+            },
+            normalizedResume: makeResume(),
+        });
+
+        const generateTailoringSuggestions = createGenerateTailoringSuggestions({
+            resumeProfiles,
+            resumeVersions,
+            generateSuggestions: async () =>
+                [
+                    {
+                        id: "suggestion-1",
+                        sectionTarget: "summary",
+                        originalContent: "old",
+                        suggestedContent: "new",
+                        rationale: "reason",
+                        relatedJobRequirements: ["payments"],
+                        priority: "urgent",
+                        confidence: "high",
+                    },
+                ] as never,
+        });
+
+        await expect(
+            generateTailoringSuggestions({
+                profileId: "profile-1",
+                jobId: "job-123",
+                sourceResumeVersionId: "version-1",
+            }),
+        ).rejects.toThrow("INVALID_TAILORING_SUGGESTIONS");
+    });
+});

--- a/packages/core/src/resumes/generate-tailoring-suggestions.ts
+++ b/packages/core/src/resumes/generate-tailoring-suggestions.ts
@@ -1,0 +1,104 @@
+import type {
+    ResumeProfile,
+    ResumeVersion,
+    TailoringSuggestion,
+} from "./types";
+
+type ResumeProfileRepository = {
+    getResumeProfileById(resumeProfileId: string): Promise<ResumeProfile | null>;
+};
+
+type ResumeVersionRepository = {
+    getResumeVersionById(resumeVersionId: string): Promise<ResumeVersion | null>;
+};
+
+function isPriority(value: unknown): value is "low" | "medium" | "high" {
+    return value === "low" || value === "medium" || value === "high";
+}
+
+function isConfidence(value: unknown): value is "low" | "medium" | "high" {
+    return value === "low" || value === "medium" || value === "high";
+}
+
+function isTailoringSuggestion(value: unknown): value is TailoringSuggestion {
+    if (!value || typeof value !== "object") {
+        return false;
+    }
+
+    const candidate = value as Record<string, unknown>;
+
+    return (
+        typeof candidate.id === "string" &&
+        typeof candidate.sectionTarget === "string" &&
+        typeof candidate.originalContent === "string" &&
+        typeof candidate.suggestedContent === "string" &&
+        typeof candidate.rationale === "string" &&
+        Array.isArray(candidate.relatedJobRequirements) &&
+        candidate.relatedJobRequirements.every(
+            (requirement) => typeof requirement === "string",
+        ) &&
+        isPriority(candidate.priority) &&
+        isConfidence(candidate.confidence)
+    );
+}
+
+function assertValidTailoringSuggestions(
+    suggestions: unknown,
+): asserts suggestions is TailoringSuggestion[] {
+    if (
+        !Array.isArray(suggestions) ||
+        !suggestions.every((suggestion) => isTailoringSuggestion(suggestion))
+    ) {
+        throw new Error("INVALID_TAILORING_SUGGESTIONS");
+    }
+}
+
+export function createGenerateTailoringSuggestions({
+    resumeProfiles,
+    resumeVersions,
+    generateSuggestions,
+}: {
+    resumeProfiles: ResumeProfileRepository;
+    resumeVersions: ResumeVersionRepository;
+    generateSuggestions(input: {
+        profileId: string;
+        jobId: string;
+        sourceResumeVersionId: string;
+        sourceResume: ResumeVersion["normalizedResume"];
+    }): Promise<unknown>;
+}) {
+    return async function generateTailoringSuggestions(input: {
+        profileId: string;
+        jobId: string;
+        sourceResumeVersionId: string;
+    }): Promise<TailoringSuggestion[]> {
+        const profile = await resumeProfiles.getResumeProfileById(input.profileId);
+
+        if (!profile) {
+            throw new Error("RESUME_PROFILE_NOT_FOUND");
+        }
+
+        const sourceVersion = await resumeVersions.getResumeVersionById(
+            input.sourceResumeVersionId,
+        );
+
+        if (!sourceVersion) {
+            throw new Error("RESUME_VERSION_NOT_FOUND");
+        }
+
+        if (sourceVersion.profileId !== input.profileId) {
+            throw new Error("RESUME_VERSION_PROFILE_MISMATCH");
+        }
+
+        const suggestions = await generateSuggestions({
+            profileId: input.profileId,
+            jobId: input.jobId,
+            sourceResumeVersionId: input.sourceResumeVersionId,
+            sourceResume: sourceVersion.normalizedResume,
+        });
+
+        assertValidTailoringSuggestions(suggestions);
+
+        return suggestions;
+    };
+}

--- a/packages/core/src/resumes/in-memory-resume-version-repository.ts
+++ b/packages/core/src/resumes/in-memory-resume-version-repository.ts
@@ -4,39 +4,48 @@ import type {
     ResumeVersion,
 } from "./types";
 
-type CreateResumeVersionInput = {
-    id?: string;
-    profileId: string;
-    versionNumber: number;
-    source: ResumeSource;
-    normalizedResume: NormalizedResume;
-};
-
 export function createInMemoryResumeVersionRepository() {
-    const resumeVersions = new Map<string, ResumeVersion>();
+    const versions: ResumeVersion[] = [];
 
     return {
-        async createResumeVersion(input: CreateResumeVersionInput) {
+        async createResumeVersion(input: {
+            id?: string;
+            profileId: string;
+            versionNumber: number;
+            kind: "baseline" | "tailored";
+            source: ResumeSource;
+            normalizedResume: NormalizedResume;
+            lineage?: ResumeVersion["lineage"];
+        }): Promise<ResumeVersion> {
             const version: ResumeVersion = {
                 id: input.id ?? crypto.randomUUID(),
                 profileId: input.profileId,
                 versionNumber: input.versionNumber,
+                kind: input.kind,
                 source: input.source,
                 normalizedResume: input.normalizedResume,
+                lineage: input.lineage,
             };
 
-            resumeVersions.set(version.id, version);
+            versions.push(version);
+
             return version;
         },
 
-        async getResumeVersionById(resumeVersionId: string) {
-            return resumeVersions.get(resumeVersionId) ?? null;
+        async listResumeVersionsByProfileId(
+            profileId: string,
+        ): Promise<ResumeVersion[]> {
+            return versions
+                .filter((version) => version.profileId === profileId)
+                .sort((a, b) => a.versionNumber - b.versionNumber);
         },
 
-        async listResumeVersionsByProfileId(resumeProfileId: string) {
-            return Array.from(resumeVersions.values())
-                .filter((version) => version.profileId === resumeProfileId)
-                .sort((a, b) => a.versionNumber - b.versionNumber);
+        async getResumeVersionById(
+            resumeVersionId: string,
+        ): Promise<ResumeVersion | null> {
+            return (
+                versions.find((version) => version.id === resumeVersionId) ?? null
+            );
         },
     };
 }

--- a/packages/core/src/resumes/review-current-resume-profile.test.ts
+++ b/packages/core/src/resumes/review-current-resume-profile.test.ts
@@ -1,89 +1,92 @@
 import { describe, expect, it } from "vitest";
 
-import { createCreateResumeProfile } from "./create-resume-profile";
 import { createInMemoryResumeProfileRepository } from "./in-memory-resume-profile-repository";
 import { createInMemoryResumeVersionRepository } from "./in-memory-resume-version-repository";
 import { createReviewCurrentResumeProfile } from "./review-current-resume-profile";
 
+function makeResume() {
+    return {
+        basics: {
+            fullName: "Jane Doe",
+            headline: "Software Engineer",
+            summary: "Backend engineer with API and platform experience.",
+        },
+        skills: ["TypeScript", "Node.js", "PostgreSQL"],
+        experience: [
+            {
+                company: "Acme",
+                title: "Software Engineer",
+                highlights: ["Built internal APIs", "Improved CI pipeline"],
+            },
+        ],
+        education: [],
+    };
+}
+
 describe("createReviewCurrentResumeProfile", () => {
-    it("reviews the current stored version for a resume profile", async () => {
-        const resumeProfiles = createInMemoryResumeProfileRepository();
-        const resumeVersions = createInMemoryResumeVersionRepository();
-
-        const createResumeProfile = createCreateResumeProfile({
-            resumeProfiles,
-            resumeVersions,
-        });
-
-        const created = await createResumeProfile({
-            name: "Baseline Resume",
-            source: {
-                kind: "manual",
-                label: "baseline-resume",
-            },
-            normalizedResume: {
-                basics: {
-                    fullName: "Ian Handley",
-                    headline: "Software Engineer",
-                    summary: "Builds reliable product systems with TypeScript and React.",
-                },
-                skills: ["TypeScript", "React", "Node.js"],
-                experience: [
-                    {
-                        company: "Acme",
-                        title: "Software Engineer",
-                        highlights: ["Built internal tools"],
-                    },
-                ],
-                education: [],
-            },
-        });
-
-        const reviewCurrentResumeProfile = createReviewCurrentResumeProfile({
-            resumeProfiles,
-            resumeVersions,
-        });
-
-        const review = await reviewCurrentResumeProfile({
-            resumeProfileId: created.profile.id,
-        });
-
-        expect(review).toMatchObject({
-            resumeProfileId: created.profile.id,
-            resumeVersionId: created.version.id,
-            review: {
-                coreStrengths: expect.any(Array),
-                missingSignals: expect.any(Array),
-                concerns: expect.any(Array),
-                targetRoleAlignment: expect.any(Array),
-                recommendedImprovements: expect.any(Array),
-            },
-        });
-    });
-
-    it("throws when the resume profile does not exist", async () => {
-        const resumeProfiles = createInMemoryResumeProfileRepository();
-        const resumeVersions = createInMemoryResumeVersionRepository();
-
-        const reviewCurrentResumeProfile = createReviewCurrentResumeProfile({
-            resumeProfiles,
-            resumeVersions,
-        });
-
-        await expect(
-            reviewCurrentResumeProfile({
-                resumeProfileId: "missing-profile-id",
-            }),
-        ).rejects.toThrow("RESUME_PROFILE_NOT_FOUND");
-    });
-
-    it("throws when the current resume version does not exist", async () => {
+    it("returns a baseline review for the current resume version", async () => {
         const resumeProfiles = createInMemoryResumeProfileRepository();
         const resumeVersions = createInMemoryResumeVersionRepository();
 
         const profile = await resumeProfiles.createResumeProfile({
-            name: "Baseline Resume",
-            currentVersionId: "missing-version-id",
+            id: "profile-1",
+            name: "Jane Doe Resume",
+            currentVersionId: "version-1",
+        });
+
+        await resumeVersions.createResumeVersion({
+            id: "version-1",
+            profileId: profile.id,
+            versionNumber: 1,
+            kind: "baseline",
+            source: {
+                kind: "upload",
+                label: "Resume.pdf",
+            },
+            normalizedResume: makeResume(),
+        });
+
+        const reviewCurrentResumeProfile = createReviewCurrentResumeProfile({
+            resumeProfiles,
+            resumeVersions,
+        });
+
+        const result = await reviewCurrentResumeProfile({
+            resumeProfileId: profile.id,
+        });
+
+        expect(result.resumeProfileId).toBe(profile.id);
+        expect(result.resumeVersionId).toBe("version-1");
+        expect(result.review.coreStrengths.length).toBeGreaterThan(0);
+        expect(Array.isArray(result.review.missingSignals)).toBe(true);
+        expect(Array.isArray(result.review.concerns)).toBe(true);
+        expect(Array.isArray(result.review.recommendedImprovements)).toBe(true);
+    });
+
+    it("throws if resume profile does not exist", async () => {
+        const resumeProfiles = createInMemoryResumeProfileRepository();
+        const resumeVersions = createInMemoryResumeVersionRepository();
+
+        const reviewCurrentResumeProfile = createReviewCurrentResumeProfile({
+            resumeProfiles,
+            resumeVersions,
+        });
+
+        await expect(
+            reviewCurrentResumeProfile({
+                resumeProfileId: "missing-profile",
+            }),
+        ).rejects.toThrow("RESUME_PROFILE_NOT_FOUND");
+    });
+
+    it("throws if current resume version does not exist", async () => {
+        const resumeProfiles = createInMemoryResumeProfileRepository();
+        const resumeVersions = createInMemoryResumeVersionRepository();
+
+        await resumeProfiles.createResumeProfile({
+            id: "profile-1",
+            name: "Jane Doe Resume",
+            currentVersionId: "missing-version",
         });
 
         const reviewCurrentResumeProfile = createReviewCurrentResumeProfile({
@@ -93,7 +96,7 @@ describe("createReviewCurrentResumeProfile", () => {
 
         await expect(
             reviewCurrentResumeProfile({
-                resumeProfileId: profile.id,
+                resumeProfileId: "profile-1",
             }),
         ).rejects.toThrow("RESUME_VERSION_NOT_FOUND");
     });

--- a/packages/core/src/resumes/types.ts
+++ b/packages/core/src/resumes/types.ts
@@ -24,12 +24,37 @@ export type ResumeProfile = {
     currentVersionId: string;
 };
 
+export type ResumeVersionKind = "baseline" | "tailored";
+
+export type TailoringSuggestion = {
+    id: string;
+    sectionTarget: string;
+    originalContent: string;
+    suggestedContent: string;
+    rationale: string;
+    relatedJobRequirements: string[];
+    priority: "low" | "medium" | "high";
+    confidence: "low" | "medium" | "high";
+};
+
+export type ResumeVersionLineage = {
+    sourceResumeVersionId?: string;
+    sourceJobId?: string;
+};
+
 export type ResumeVersion = {
     id: string;
     profileId: string;
     versionNumber: number;
+    kind: ResumeVersionKind;
     source: ResumeSource;
     normalizedResume: NormalizedResume;
+    lineage?: ResumeVersionLineage;
+};
+
+export type TailoredResume = {
+    version: ResumeVersion;
+    suggestions: TailoringSuggestion[];
 };
 
 export type BaselineResumeReview = {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -4,3 +4,5 @@ export * from "./jobs/create-db-job-importer";
 export * from "./evaluations";
 export * from "./resume-profiles";
 export * from "./resume-versions";
+export * from "./resume-versions/create-db-create-tailored-resume";
+export * from "./resume-versions/create-db-generate-tailoring-suggestions";

--- a/packages/db/src/resume-versions/create-db-create-tailored-resume.ts
+++ b/packages/db/src/resume-versions/create-db-create-tailored-resume.ts
@@ -1,0 +1,45 @@
+import { createCreateTailoredResume } from "@coach/core";
+
+export function createDbCreateTailoredResume({
+    resumeProfiles,
+    resumeVersions,
+    generateTailoringSuggestions,
+}: {
+    resumeProfiles: {
+        getResumeProfileById(resumeProfileId: string): Promise<any>;
+        updateResumeProfileCurrentVersion(input: {
+            resumeProfileId: string;
+            currentVersionId: string;
+        }): Promise<any>;
+    };
+    resumeVersions: {
+        getResumeVersionById(resumeVersionId: string): Promise<any>;
+        createResumeVersion(input: {
+            id?: string;
+            profileId: string;
+            versionNumber: number;
+            kind: "tailored";
+            source: {
+                kind: string;
+                label: string;
+            };
+            normalizedResume: any;
+            lineage?: {
+                sourceResumeVersionId?: string;
+                sourceJobId?: string;
+            };
+        }): Promise<any>;
+        listResumeVersionsByProfileId(profileId: string): Promise<any[]>;
+    };
+    generateTailoringSuggestions(input: {
+        profileId: string;
+        jobId: string;
+        sourceResumeVersionId: string;
+    }): Promise<unknown>;
+}) {
+    return createCreateTailoredResume({
+        resumeProfiles,
+        resumeVersions,
+        generateTailoringSuggestions,
+    });
+}

--- a/packages/db/src/resume-versions/create-db-generate-tailoring-suggestions.test.ts
+++ b/packages/db/src/resume-versions/create-db-generate-tailoring-suggestions.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { createDbGenerateTailoringSuggestions } from "./create-db-generate-tailoring-suggestions";
+
+describe("createDbGenerateTailoringSuggestions", () => {
+    it("creates a DB-backed tailoring suggestion service", async () => {
+        const resumeProfiles = {
+            getResumeProfileById: async (resumeProfileId: string) =>
+                resumeProfileId === "profile-1"
+                    ? {
+                        id: "profile-1",
+                        name: "Jane Doe Resume",
+                        currentVersionId: "version-1",
+                    }
+                    : null,
+        };
+
+        const resumeVersions = {
+            getResumeVersionById: async (resumeVersionId: string) =>
+                resumeVersionId === "version-1"
+                    ? {
+                        id: "version-1",
+                        profileId: "profile-1",
+                        versionNumber: 1,
+                        kind: "baseline" as const,
+                        source: {
+                            kind: "upload",
+                            label: "Resume.pdf",
+                        },
+                        normalizedResume: {
+                            basics: {
+                                fullName: "Jane Doe",
+                                headline: "Software Engineer",
+                                summary: "Backend engineer with API and platform experience.",
+                            },
+                            skills: ["TypeScript", "Node.js", "PostgreSQL"],
+                            experience: [
+                                {
+                                    company: "Acme",
+                                    title: "Software Engineer",
+                                    highlights: ["Built internal APIs"],
+                                },
+                            ],
+                            education: [],
+                        },
+                    }
+                    : null,
+        };
+
+        const generateTailoringSuggestions = createDbGenerateTailoringSuggestions({
+            resumeProfiles,
+            resumeVersions,
+            generateSuggestions: async () => [
+                {
+                    id: "suggestion-1",
+                    sectionTarget: "summary",
+                    originalContent: "Backend engineer with API and platform experience.",
+                    suggestedContent:
+                        "Backend engineer with API, platform, and fintech integration experience.",
+                    rationale: "Align summary with the target job domain.",
+                    relatedJobRequirements: ["payments", "backend systems"],
+                    priority: "high" as const,
+                    confidence: "high" as const,
+                },
+            ],
+        });
+
+        const result = await generateTailoringSuggestions({
+            profileId: "profile-1",
+            jobId: "job-123",
+            sourceResumeVersionId: "version-1",
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+            id: "suggestion-1",
+            sectionTarget: "summary",
+            priority: "high",
+            confidence: "high",
+        });
+    });
+});

--- a/packages/db/src/resume-versions/create-db-generate-tailoring-suggestions.ts
+++ b/packages/db/src/resume-versions/create-db-generate-tailoring-suggestions.ts
@@ -1,0 +1,26 @@
+import { createGenerateTailoringSuggestions } from "@coach/core";
+
+export function createDbGenerateTailoringSuggestions({
+    resumeProfiles,
+    resumeVersions,
+    generateSuggestions,
+}: {
+    resumeProfiles: {
+        getResumeProfileById(resumeProfileId: string): Promise<any>;
+    };
+    resumeVersions: {
+        getResumeVersionById(resumeVersionId: string): Promise<any>;
+    };
+    generateSuggestions(input: {
+        profileId: string;
+        jobId: string;
+        sourceResumeVersionId: string;
+        sourceResume: any;
+    }): Promise<unknown>;
+}) {
+    return createGenerateTailoringSuggestions({
+        resumeProfiles,
+        resumeVersions,
+        generateSuggestions,
+    });
+}

--- a/packages/db/src/resume-versions/db-resume-version-repository.test.ts
+++ b/packages/db/src/resume-versions/db-resume-version-repository.test.ts
@@ -10,6 +10,7 @@ describe("createDbResumeVersionRepository", () => {
                 id: string;
                 profile_id: string;
                 version_number: number;
+                kind: "baseline" | "tailored";
                 source_kind: string;
                 source_label: string;
                 normalized_resume: {
@@ -26,6 +27,8 @@ describe("createDbResumeVersionRepository", () => {
                     }>;
                     education: unknown[];
                 };
+                source_resume_version_id: string | null;
+                source_job_id: string | null;
             }
         >();
 
@@ -38,6 +41,7 @@ describe("createDbResumeVersionRepository", () => {
                         id?: string;
                         profile_id: string;
                         version_number: number;
+                        kind: "baseline" | "tailored";
                         source_kind: string;
                         source_label: string;
                         normalized_resume: {
@@ -54,14 +58,19 @@ describe("createDbResumeVersionRepository", () => {
                             }>;
                             education: unknown[];
                         };
+                        source_resume_version_id: string | null;
+                        source_job_id: string | null;
                     }) {
                         const row = {
                             id: input.id ?? crypto.randomUUID(),
                             profile_id: input.profile_id,
                             version_number: input.version_number,
+                            kind: input.kind,
                             source_kind: input.source_kind,
                             source_label: input.source_label,
                             normalized_resume: input.normalized_resume,
+                            source_resume_version_id: input.source_resume_version_id,
+                            source_job_id: input.source_job_id,
                         };
 
                         rows.set(row.id, row);
@@ -88,8 +97,7 @@ describe("createDbResumeVersionRepository", () => {
                                     expect(operator).toBe("=");
 
                                     return {
-                                        executeTakeFirst: async () =>
-                                            rows.get(value) ?? undefined,
+                                        executeTakeFirst: async () => rows.get(value) ?? undefined,
                                     };
                                 }
 
@@ -104,14 +112,9 @@ describe("createDbResumeVersionRepository", () => {
                                             return {
                                                 execute: async () =>
                                                     Array.from(rows.values())
-                                                        .filter(
-                                                            (row) =>
-                                                                row.profile_id === value,
-                                                        )
+                                                        .filter((row) => row.profile_id === value)
                                                         .sort(
-                                                            (a, b) =>
-                                                                a.version_number -
-                                                                b.version_number,
+                                                            (a, b) => a.version_number - b.version_number,
                                                         ),
                                             };
                                         },
@@ -131,6 +134,7 @@ describe("createDbResumeVersionRepository", () => {
         const created = await repo.createResumeVersion({
             profileId: "profile-1",
             versionNumber: 1,
+            kind: "baseline",
             source: {
                 kind: "manual",
                 label: "baseline-resume",
@@ -157,10 +161,12 @@ describe("createDbResumeVersionRepository", () => {
             id: expect.any(String),
             profileId: "profile-1",
             versionNumber: 1,
+            kind: "baseline",
             source: {
                 kind: "manual",
                 label: "baseline-resume",
             },
+            lineage: undefined,
         });
 
         const fetched = await repo.getResumeVersionById(created.id);
@@ -170,6 +176,7 @@ describe("createDbResumeVersionRepository", () => {
         await repo.createResumeVersion({
             profileId: "profile-1",
             versionNumber: 2,
+            kind: "tailored",
             source: {
                 kind: "manual",
                 label: "baseline-resume-v2",
@@ -190,12 +197,27 @@ describe("createDbResumeVersionRepository", () => {
                 ],
                 education: [],
             },
+            lineage: {
+                sourceResumeVersionId: created.id,
+                sourceJobId: "job-123",
+            },
         });
 
         const listed = await repo.listResumeVersionsByProfileId("profile-1");
 
         expect(listed).toHaveLength(2);
-        const versionNumbers = listed.map((version: { versionNumber: number }) => version.versionNumber);
+        const versionNumbers = listed.map(
+            (version: { versionNumber: number }) => version.versionNumber,
+        );
         expect(versionNumbers).toEqual([1, 2]);
+
+        expect(listed[1]).toMatchObject({
+            versionNumber: 2,
+            kind: "tailored",
+            lineage: {
+                sourceResumeVersionId: created.id,
+                sourceJobId: "job-123",
+            },
+        });
     });
 });

--- a/packages/db/src/resume-versions/db-resume-version-repository.ts
+++ b/packages/db/src/resume-versions/db-resume-version-repository.ts
@@ -1,24 +1,35 @@
-import type { NormalizedResume, ResumeSource } from "@coach/core";
+import type { NormalizedResume, ResumeSource, ResumeVersion } from "@coach/core";
 
 type DbResumeVersionRow = {
     id: string;
     profile_id: string;
     version_number: number;
+    kind: "baseline" | "tailored";
     source_kind: string;
     source_label: string;
     normalized_resume: NormalizedResume;
+    source_resume_version_id: string | null;
+    source_job_id: string | null;
 };
 
-function mapResumeVersion(row: DbResumeVersionRow) {
+function mapResumeVersion(row: DbResumeVersionRow): ResumeVersion {
     return {
         id: row.id,
         profileId: row.profile_id,
         versionNumber: row.version_number,
+        kind: row.kind,
         source: {
             kind: row.source_kind,
             label: row.source_label,
         },
         normalizedResume: row.normalized_resume,
+        lineage:
+            row.source_resume_version_id || row.source_job_id
+                ? {
+                    sourceResumeVersionId: row.source_resume_version_id ?? undefined,
+                    sourceJobId: row.source_job_id ?? undefined,
+                }
+                : undefined,
     };
 }
 
@@ -28,8 +39,13 @@ export function createDbResumeVersionRepository({ db }: { db: any }) {
             id?: string;
             profileId: string;
             versionNumber: number;
+            kind: "baseline" | "tailored";
             source: ResumeSource;
             normalizedResume: NormalizedResume;
+            lineage?: {
+                sourceResumeVersionId?: string;
+                sourceJobId?: string;
+            };
         }) {
             const row = await db
                 .insertInto("resume_versions")
@@ -37,9 +53,12 @@ export function createDbResumeVersionRepository({ db }: { db: any }) {
                     id: input.id,
                     profile_id: input.profileId,
                     version_number: input.versionNumber,
+                    kind: input.kind,
                     source_kind: input.source.kind,
                     source_label: input.source.label,
                     normalized_resume: input.normalizedResume,
+                    source_resume_version_id: input.lineage?.sourceResumeVersionId ?? null,
+                    source_job_id: input.lineage?.sourceJobId ?? null,
                 })
                 .returningAll()
                 .executeTakeFirstOrThrow();

--- a/packages/db/src/resume-versions/index.ts
+++ b/packages/db/src/resume-versions/index.ts
@@ -1,2 +1,4 @@
 export * from "./db-resume-version-repository";
 export * from "./create-db-create-resume-version";
+export * from "./create-db-create-tailored-resume";
+export * from "./create-db-generate-tailoring-suggestions";

--- a/scripts/session-start.sh
+++ b/scripts/session-start.sh
@@ -24,6 +24,8 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   exit 1
 fi
 
+REPO_URL=$(git remote get-url origin 2>/dev/null | sed -E 's/git@github.com:/https:\/\/github.com\//' | sed -E 's/\.git$//')
+
 # ----------------------------------------
 # Sync main
 # ----------------------------------------
@@ -43,6 +45,11 @@ if [[ -n "$ISSUE_FILE" ]]; then
   SLUG=$(echo "$ISSUE_FILE" | sed -E "s/^[0-9]+-//" | sed -E "s/\.md$//")
 else
   SLUG="issue-$ISSUE_NUMBER"
+fi
+
+ISSUE_PATH=""
+if [[ -n "$ISSUE_FILE" ]]; then
+  ISSUE_PATH=".ai/issues/$ISSUE_FILE"
 fi
 
 # normalize slug for branch
@@ -138,13 +145,27 @@ echo ""
 echo "========================================"
 echo "SESSION READY"
 echo "========================================"
+echo "Repo:   ${REPO_URL:-"(unknown)"}"
 echo "Issue:  #$ISSUE_NUMBER"
 echo "Branch: $BRANCH_NAME"
 echo "PR:     ${PR_URL:-"(not created yet)"}"
+
+if [[ -n "$ISSUE_PATH" ]]; then
+  echo "Issue File: $ISSUE_PATH"
+fi
 
 if [[ -n "$PR_STATUS_NOTE" ]]; then
   echo "Note:   $PR_STATUS_NOTE"
 fi
 
 echo ""
+
+if [[ -n "$ISSUE_PATH" && -f "$ISSUE_PATH" ]]; then
+  echo "----------------------------------------"
+  echo "ISSUE CONTENT"
+  echo "----------------------------------------"
+  sed -n '1,200p' "$ISSUE_PATH"
+  echo ""
+fi
+
 echo "You can begin work."


### PR DESCRIPTION
<h1>Summary</h1>
<ul>
  <li>Add resume tailoring workflow for structured suggestions and versioned tailored resumes.</li>
</ul>

<h1>Changes</h1>
<ul>
  <li>Add core tailoring suggestion service with validation for malformed generated output</li>
  <li>Add core tailored resume creation service with lineage and repeated-version behavior</li>
  <li>Extend resume version models and repositories to support <code>kind</code> and lineage fields</li>
  <li>Add DB repository support for tailored resume version persistence</li>
  <li>Add DB wrappers for tailoring suggestion generation and tailored resume creation</li>
  <li>Add API route for <code>POST /api/resume-profiles/[resumeProfileId]/tailoring-suggestions</code></li>
  <li>Add API route for <code>POST /api/resume-profiles/[resumeProfileId]/tailored-resumes</code></li>
  <li>Add tests across core, DB, and API layers for validation, lineage, reruns, and error handling</li>
  <li>Closes #6</li>
</ul>