### PR TITLE
Issue #9: stage-9-add-workflow-orchestration-background-jobs-retries-and-run-history

### DIFF
--- a/apps/job-coach-web/src/app/api/workflows/[workflowRunId]/route.test.ts
+++ b/apps/job-coach-web/src/app/api/workflows/[workflowRunId]/route.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const getWorkflowRunMock = vi.fn();
+
+vi.mock("../../../../server/workflows-server", () => {
+    return {
+        workflowsServer: {
+            getWorkflowRun: getWorkflowRunMock,
+        },
+    };
+});
+
+describe("GET /api/workflows/[workflowRunId]", () => {
+    afterEach(() => {
+        getWorkflowRunMock.mockReset();
+    });
+
+    it("returns workflow run details", async () => {
+        const { GET } = await import("./route");
+
+        getWorkflowRunMock.mockResolvedValue({
+            workflowRun: {
+                id: "run-1",
+                workflowType: "import-job-and-score-fit",
+                status: "succeeded",
+            },
+            workflowSteps: [
+                {
+                    id: "step-1",
+                    workflowRunId: "run-1",
+                    stepKey: "import-job",
+                    status: "succeeded",
+                    attemptCount: 1,
+                },
+            ],
+        });
+
+        const response = await GET(new Request("http://localhost"), {
+            params: Promise.resolve({ workflowRunId: "run-1" }),
+        });
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({
+            workflowRun: {
+                id: "run-1",
+                workflowType: "import-job-and-score-fit",
+                status: "succeeded",
+            },
+            workflowSteps: [
+                {
+                    id: "step-1",
+                    workflowRunId: "run-1",
+                    stepKey: "import-job",
+                    status: "succeeded",
+                    attemptCount: 1,
+                },
+            ],
+        });
+
+        expect(getWorkflowRunMock).toHaveBeenCalledWith({
+            workflowRunId: "run-1",
+        });
+    });
+
+    it("returns 404 when workflow run is missing", async () => {
+        const { GET } = await import("./route");
+
+        getWorkflowRunMock.mockResolvedValue(null);
+
+        const response = await GET(new Request("http://localhost"), {
+            params: Promise.resolve({ workflowRunId: "missing-run" }),
+        });
+
+        expect(response.status).toBe(404);
+        expect(await response.json()).toEqual({
+            error: "WORKFLOW_RUN_NOT_FOUND",
+        });
+    });
+});

--- a/apps/job-coach-web/src/app/api/workflows/[workflowRunId]/route.ts
+++ b/apps/job-coach-web/src/app/api/workflows/[workflowRunId]/route.ts
@@ -1,0 +1,18 @@
+import { workflowsServer } from "../../../../server/workflows-server";
+
+export async function GET(
+    _request: Request,
+    context: { params: Promise<{ workflowRunId: string }> },
+) {
+    const { workflowRunId } = await context.params;
+
+    const result = await workflowsServer.getWorkflowRun({
+        workflowRunId,
+    });
+
+    if (!result) {
+        return Response.json({ error: "WORKFLOW_RUN_NOT_FOUND" }, { status: 404 });
+    }
+
+    return Response.json(result, { status: 200 });
+}

--- a/apps/job-coach-web/src/app/api/workflows/route.test.ts
+++ b/apps/job-coach-web/src/app/api/workflows/route.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const listWorkflowRunsMock = vi.fn();
+const startImportJobAndScoreFitWorkflowMock = vi.fn();
+const startGenerateApplicationMaterialsWorkflowMock = vi.fn();
+
+vi.mock("../../../server/workflows-server", () => {
+    return {
+        workflowsServer: {
+            listWorkflowRuns: listWorkflowRunsMock,
+            startImportJobAndScoreFitWorkflow:
+                startImportJobAndScoreFitWorkflowMock,
+            startGenerateApplicationMaterialsWorkflow:
+                startGenerateApplicationMaterialsWorkflowMock,
+        },
+    };
+});
+
+describe("GET /api/workflows", () => {
+    afterEach(() => {
+        listWorkflowRunsMock.mockReset();
+        startImportJobAndScoreFitWorkflowMock.mockReset();
+        startGenerateApplicationMaterialsWorkflowMock.mockReset();
+    });
+
+    it("returns workflow runs", async () => {
+        const { GET } = await import("./route");
+
+        listWorkflowRunsMock.mockResolvedValue([
+            {
+                id: "run-1",
+                workflowType: "import-job-and-score-fit",
+                status: "succeeded",
+            },
+        ]);
+
+        const response = await GET();
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual([
+            {
+                id: "run-1",
+                workflowType: "import-job-and-score-fit",
+                status: "succeeded",
+            },
+        ]);
+    });
+});
+
+describe("POST /api/workflows", () => {
+    afterEach(() => {
+        listWorkflowRunsMock.mockReset();
+        startImportJobAndScoreFitWorkflowMock.mockReset();
+        startGenerateApplicationMaterialsWorkflowMock.mockReset();
+    });
+
+    it("starts import-job-and-score-fit workflow", async () => {
+        const { POST } = await import("./route");
+
+        startImportJobAndScoreFitWorkflowMock.mockResolvedValue({
+            id: "run-1",
+            workflowType: "import-job-and-score-fit",
+            status: "succeeded",
+        });
+
+        const response = await POST(
+            new Request("http://localhost/api/workflows", {
+                method: "POST",
+                body: JSON.stringify({
+                    workflowType: "import-job-and-score-fit",
+                    sourceUrl: "https://example.com/jobs/123",
+                    resumeProfileId: "resume-profile-1",
+                }),
+                headers: {
+                    "content-type": "application/json",
+                },
+            }),
+        );
+
+        expect(response.status).toBe(201);
+        expect(await response.json()).toEqual({
+            id: "run-1",
+            workflowType: "import-job-and-score-fit",
+            status: "succeeded",
+        });
+
+        expect(startImportJobAndScoreFitWorkflowMock).toHaveBeenCalledWith({
+            sourceUrl: "https://example.com/jobs/123",
+            resumeProfileId: "resume-profile-1",
+        });
+    });
+
+    it("starts generate-application-materials workflow", async () => {
+        const { POST } = await import("./route");
+
+        startGenerateApplicationMaterialsWorkflowMock.mockResolvedValue({
+            id: "run-2",
+            workflowType: "generate-application-materials",
+            status: "succeeded",
+        });
+
+        const response = await POST(
+            new Request("http://localhost/api/workflows", {
+                method: "POST",
+                body: JSON.stringify({
+                    workflowType: "generate-application-materials",
+                    resumeProfileId: "rp1",
+                    resumeVersionId: "rv1",
+                    jobId: "job1",
+                    format: "pdf",
+                }),
+                headers: {
+                    "content-type": "application/json",
+                },
+            }),
+        );
+
+        expect(response.status).toBe(201);
+        expect(await response.json()).toEqual({
+            id: "run-2",
+            workflowType: "generate-application-materials",
+            status: "succeeded",
+        });
+
+        expect(
+            startGenerateApplicationMaterialsWorkflowMock,
+        ).toHaveBeenCalledWith({
+            resumeProfileId: "rp1",
+            resumeVersionId: "rv1",
+            jobId: "job1",
+            format: "pdf",
+        });
+    });
+
+    it("returns 400 for invalid input", async () => {
+        const { POST } = await import("./route");
+
+        const response = await POST(
+            new Request("http://localhost/api/workflows", {
+                method: "POST",
+                body: JSON.stringify({
+                    workflowType: "import-job-and-score-fit",
+                    sourceUrl: "https://example.com/jobs/123",
+                }),
+                headers: {
+                    "content-type": "application/json",
+                },
+            }),
+        );
+
+        expect(response.status).toBe(400);
+        expect(startImportJobAndScoreFitWorkflowMock).not.toHaveBeenCalled();
+        expect(
+            startGenerateApplicationMaterialsWorkflowMock,
+        ).not.toHaveBeenCalled();
+    });
+
+    it("returns 500 when workflow execution fails", async () => {
+        const { POST } = await import("./route");
+
+        startImportJobAndScoreFitWorkflowMock.mockRejectedValue(
+            new Error("SCORING_UNAVAILABLE"),
+        );
+
+        const response = await POST(
+            new Request("http://localhost/api/workflows", {
+                method: "POST",
+                body: JSON.stringify({
+                    workflowType: "import-job-and-score-fit",
+                    sourceUrl: "https://example.com/jobs/123",
+                    resumeProfileId: "resume-profile-1",
+                }),
+                headers: {
+                    "content-type": "application/json",
+                },
+            }),
+        );
+
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({
+            error: "SCORING_UNAVAILABLE",
+        });
+    });
+});

--- a/apps/job-coach-web/src/app/api/workflows/route.ts
+++ b/apps/job-coach-web/src/app/api/workflows/route.ts
@@ -1,0 +1,83 @@
+import { workflowsServer } from "../../../server/workflows-server";
+
+function isNonEmptyString(value: unknown): value is string {
+    return typeof value === "string" && value.trim().length > 0;
+}
+
+function isWorkflowType(
+    value: unknown,
+): value is "import-job-and-score-fit" | "generate-application-materials" {
+    return (
+        value === "import-job-and-score-fit" ||
+        value === "generate-application-materials"
+    );
+}
+
+function isFormat(value: unknown): value is "pdf" | "docx" {
+    return value === "pdf" || value === "docx";
+}
+
+export async function GET() {
+    const runs = await workflowsServer.listWorkflowRuns();
+
+    return Response.json(runs, { status: 200 });
+}
+
+export async function POST(request: Request) {
+    const body = await request.json();
+
+    if (!body || !isWorkflowType(body.workflowType)) {
+        return Response.json({ error: "INVALID_WORKFLOW_INPUT" }, { status: 400 });
+    }
+
+    try {
+        if (body.workflowType === "import-job-and-score-fit") {
+            if (
+                !isNonEmptyString(body.sourceUrl) ||
+                !isNonEmptyString(body.resumeProfileId)
+            ) {
+                return Response.json(
+                    { error: "INVALID_WORKFLOW_INPUT" },
+                    { status: 400 },
+                );
+            }
+
+            const result =
+                await workflowsServer.startImportJobAndScoreFitWorkflow({
+                    sourceUrl: body.sourceUrl,
+                    resumeProfileId: body.resumeProfileId,
+                });
+
+            return Response.json(result, { status: 201 });
+        }
+
+        if (
+            !isNonEmptyString(body.resumeProfileId) ||
+            !isNonEmptyString(body.resumeVersionId) ||
+            !isNonEmptyString(body.jobId) ||
+            (body.format !== undefined && !isFormat(body.format))
+        ) {
+            return Response.json({ error: "INVALID_WORKFLOW_INPUT" }, { status: 400 });
+        }
+
+        const result =
+            await workflowsServer.startGenerateApplicationMaterialsWorkflow({
+                resumeProfileId: body.resumeProfileId,
+                resumeVersionId: body.resumeVersionId,
+                jobId: body.jobId,
+                format: body.format,
+            });
+
+        return Response.json(result, { status: 201 });
+    } catch (error) {
+        const message =
+            error instanceof Error ? error.message : "WORKFLOW_EXECUTION_FAILED";
+
+        return Response.json(
+            {
+                error: message,
+            },
+            { status: 500 },
+        );
+    }
+}

--- a/apps/job-coach-web/src/server/generate-application-materials-workflow.test.ts
+++ b/apps/job-coach-web/src/server/generate-application-materials-workflow.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest";
+import { createInMemoryWorkflowRunRepository } from "@coach/core";
+import { createGenerateApplicationMaterialsWorkflow } from "./generate-application-materials-workflow";
+
+describe("createGenerateApplicationMaterialsWorkflow", () => {
+    it("runs the happy path and records workflow history", async () => {
+        const workflowRunRepository = createInMemoryWorkflowRunRepository();
+
+        const createTailoredResume = vi.fn().mockResolvedValue({
+            id: "tailored-resume-1",
+        });
+
+        const createCoverLetterDraft = vi.fn().mockResolvedValue({
+            id: "cover-letter-1",
+        });
+
+        const exportApplicationPacket = vi.fn().mockResolvedValue({
+            fileName: "application-packet-rp1-tailored-resume-1-cover-letter-1.pdf",
+        });
+
+        const workflow = createGenerateApplicationMaterialsWorkflow({
+            workflowRunRepository,
+            createTailoredResume,
+            createCoverLetterDraft,
+            exportApplicationPacket,
+        });
+
+        const result = await workflow.start({
+            resumeProfileId: "rp1",
+            resumeVersionId: "rv1",
+            jobId: "job1",
+            format: "pdf",
+        });
+
+        expect(createTailoredResume).toHaveBeenCalledWith({
+            resumeProfileId: "rp1",
+            resumeVersionId: "rv1",
+            jobId: "job1",
+        });
+
+        expect(createCoverLetterDraft).toHaveBeenCalledWith({
+            resumeProfileId: "rp1",
+            jobId: "job1",
+        });
+
+        expect(exportApplicationPacket).toHaveBeenCalledWith({
+            resumeProfileId: "rp1",
+            resumeVersionId: "tailored-resume-1",
+            coverLetterDraftId: "cover-letter-1",
+            format: "pdf",
+        });
+
+        expect(result).toMatchObject({
+            id: expect.any(String),
+            workflowType: "generate-application-materials",
+            status: "succeeded",
+            input: {
+                resumeProfileId: "rp1",
+                resumeVersionId: "rv1",
+                jobId: "job1",
+                format: "pdf",
+            },
+        });
+
+        const steps = await workflowRunRepository.listWorkflowStepsByRunId(
+            result!.id,
+        );
+
+        expect(steps).toHaveLength(3);
+        expect(steps[0]).toMatchObject({
+            stepKey: "generate-tailored-resume",
+            status: "succeeded",
+            attemptCount: 1,
+        });
+        expect(steps[1]).toMatchObject({
+            stepKey: "generate-cover-letter",
+            status: "succeeded",
+            attemptCount: 1,
+        });
+        expect(steps[2]).toMatchObject({
+            stepKey: "export-application-packet",
+            status: "succeeded",
+            attemptCount: 1,
+        });
+    });
+
+    it("records a failed run when packet export fails", async () => {
+        const workflowRunRepository = createInMemoryWorkflowRunRepository();
+
+        const createTailoredResume = vi.fn().mockResolvedValue({
+            id: "tailored-resume-1",
+        });
+
+        const createCoverLetterDraft = vi.fn().mockResolvedValue({
+            id: "cover-letter-1",
+        });
+
+        const exportApplicationPacket = vi
+            .fn()
+            .mockRejectedValue(new Error("EXPORT_PACKET_FAILED"));
+
+        const workflow = createGenerateApplicationMaterialsWorkflow({
+            workflowRunRepository,
+            createTailoredResume,
+            createCoverLetterDraft,
+            exportApplicationPacket,
+        });
+
+        await expect(
+            workflow.start({
+                resumeProfileId: "rp1",
+                resumeVersionId: "rv1",
+                jobId: "job1",
+                format: "pdf",
+            }),
+        ).rejects.toThrow("EXPORT_PACKET_FAILED");
+
+        const runs = await workflowRunRepository.listWorkflowRuns();
+
+        expect(runs).toHaveLength(1);
+        expect(runs[0]).toMatchObject({
+            workflowType: "generate-application-materials",
+            status: "failed",
+            currentStepKey: "export-application-packet",
+            errorMessage: "EXPORT_PACKET_FAILED",
+            retryCount: 1,
+        });
+
+        const steps = await workflowRunRepository.listWorkflowStepsByRunId(
+            runs[0].id,
+        );
+
+        expect(steps).toHaveLength(3);
+        expect(steps[2]).toMatchObject({
+            stepKey: "export-application-packet",
+            status: "failed",
+            attemptCount: 3,
+            errorMessage: "EXPORT_PACKET_FAILED",
+        });
+    });
+});

--- a/apps/job-coach-web/src/server/generate-application-materials-workflow.ts
+++ b/apps/job-coach-web/src/server/generate-application-materials-workflow.ts
@@ -1,0 +1,96 @@
+import { runWorkflow, type WorkflowRunRepository } from "@coach/core";
+
+export function createGenerateApplicationMaterialsWorkflow(dependencies: {
+    workflowRunRepository: WorkflowRunRepository;
+    createTailoredResume(input: {
+        resumeProfileId: string;
+        resumeVersionId: string;
+        jobId: string;
+    }): Promise<{ id: string }>;
+    createCoverLetterDraft(input: {
+        resumeProfileId: string;
+        jobId: string;
+    }): Promise<{ id: string }>;
+    exportApplicationPacket(input: {
+        resumeProfileId: string;
+        resumeVersionId: string;
+        coverLetterDraftId: string;
+        format: "pdf" | "docx";
+    }): Promise<unknown>;
+}) {
+    return {
+        async start(input: {
+            resumeProfileId: string;
+            resumeVersionId: string;
+            jobId: string;
+            format?: "pdf" | "docx";
+        }) {
+            const workflowRun =
+                await dependencies.workflowRunRepository.createWorkflowRun({
+                    workflowType: "generate-application-materials",
+                    input: {
+                        resumeProfileId: input.resumeProfileId,
+                        resumeVersionId: input.resumeVersionId,
+                        jobId: input.jobId,
+                        format: input.format ?? "pdf",
+                    },
+                    status: "queued",
+                });
+
+            let tailoredResumeId: string | undefined;
+            let coverLetterDraftId: string | undefined;
+
+            await runWorkflow({
+                workflowRunRepository: dependencies.workflowRunRepository,
+                workflowRunId: workflowRun.id,
+                steps: [
+                    {
+                        stepKey: "generate-tailored-resume",
+                        run: async () => {
+                            const tailoredResume =
+                                await dependencies.createTailoredResume({
+                                    resumeProfileId: input.resumeProfileId,
+                                    resumeVersionId: input.resumeVersionId,
+                                    jobId: input.jobId,
+                                });
+
+                            tailoredResumeId = tailoredResume.id;
+                        },
+                    },
+                    {
+                        stepKey: "generate-cover-letter",
+                        run: async () => {
+                            const coverLetter =
+                                await dependencies.createCoverLetterDraft({
+                                    resumeProfileId: input.resumeProfileId,
+                                    jobId: input.jobId,
+                                });
+
+                            coverLetterDraftId = coverLetter.id;
+                        },
+                    },
+                    {
+                        stepKey: "export-application-packet",
+                        run: async () => {
+                            if (!coverLetterDraftId) {
+                                throw new Error("MISSING_COVER_LETTER_DRAFT_ID");
+                            }
+
+                            await dependencies.exportApplicationPacket({
+                                resumeProfileId: input.resumeProfileId,
+                                resumeVersionId:
+                                    tailoredResumeId ?? input.resumeVersionId,
+                                coverLetterDraftId,
+                                format: input.format ?? "pdf",
+                            });
+                        },
+                    },
+                ],
+            });
+
+            return dependencies.workflowRunRepository.getWorkflowRunById(
+                workflowRun.id,
+            );
+        },
+    };
+}

--- a/apps/job-coach-web/src/server/workflows-server.ts
+++ b/apps/job-coach-web/src/server/workflows-server.ts
@@ -1,0 +1,18 @@
+import { createServerClient } from "@coach/db";
+import { createDbWorkflowRunRepository } from "@coach/db";
+import { importJobFromUrl } from "./jobs";
+import { evaluationsServer } from "./evaluations/server";
+import { createWorkflowsServer } from "./workflows";
+
+const db = createServerClient();
+const workflowRunRepository = createDbWorkflowRunRepository({ db });
+
+export const workflowsServer = createWorkflowsServer({
+    workflowRunRepository,
+    importJobFromUrl: async ({ sourceUrl }) => importJobFromUrl(sourceUrl),
+    scoreJobFit: async ({ jobId, resumeProfileId }) =>
+        evaluationsServer.scoreJobFit({
+            jobId,
+            resumeProfileId,
+        }),
+});

--- a/apps/job-coach-web/src/server/workflows.test.ts
+++ b/apps/job-coach-web/src/server/workflows.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from "vitest";
+import { createInMemoryWorkflowRunRepository } from "@coach/core";
+import { createWorkflowsServer } from "./workflows";
+
+describe("createWorkflowsServer", () => {
+    it("runs import-job-and-score-fit workflow and stores run history", async () => {
+        const workflowRunRepository = createInMemoryWorkflowRunRepository();
+
+        const importJobFromUrl = vi.fn().mockResolvedValue({
+            id: "job-123",
+        });
+
+        const scoreJobFit = vi.fn().mockResolvedValue({
+            score: 82,
+        });
+
+        const server = createWorkflowsServer({
+            workflowRunRepository,
+            importJobFromUrl,
+            scoreJobFit,
+        });
+
+        const result = await server.startImportJobAndScoreFitWorkflow({
+            sourceUrl: "https://example.com/jobs/123",
+            resumeProfileId: "resume-profile-1",
+        });
+
+        expect(importJobFromUrl).toHaveBeenCalledWith({
+            sourceUrl: "https://example.com/jobs/123",
+        });
+
+        expect(scoreJobFit).toHaveBeenCalledWith({
+            jobId: "job-123",
+            resumeProfileId: "resume-profile-1",
+        });
+
+        expect(result).toMatchObject({
+            id: expect.any(String),
+            workflowType: "import-job-and-score-fit",
+            status: "succeeded",
+            input: {
+                sourceUrl: "https://example.com/jobs/123",
+                resumeProfileId: "resume-profile-1",
+            },
+        });
+
+        const workflowRunId = result?.id;
+
+        expect(workflowRunId).toBeDefined();
+
+        const workflowStatus = await server.getWorkflowRun({
+            workflowRunId: workflowRunId!,
+        });
+
+        expect(workflowStatus).toMatchObject({
+            workflowRun: {
+                id: workflowRunId,
+                status: "succeeded",
+            },
+        });
+
+        expect(workflowStatus?.workflowSteps).toHaveLength(2);
+        expect(workflowStatus?.workflowSteps[0]).toMatchObject({
+            stepKey: "import-job",
+            status: "succeeded",
+            attemptCount: 1,
+        });
+        expect(workflowStatus?.workflowSteps[1]).toMatchObject({
+            stepKey: "score-fit",
+            status: "succeeded",
+            attemptCount: 1,
+        });
+
+        const runs = await server.listWorkflowRuns();
+
+        expect(runs).toHaveLength(1);
+        expect(runs[0]).toMatchObject({
+            id: workflowRunId,
+            workflowType: "import-job-and-score-fit",
+            status: "succeeded",
+        });
+    });
+
+    it("stores failure details when a workflow step fails", async () => {
+        const workflowRunRepository = createInMemoryWorkflowRunRepository();
+
+        const importJobFromUrl = vi.fn().mockResolvedValue({
+            id: "job-123",
+        });
+
+        const scoreJobFit = vi
+            .fn()
+            .mockRejectedValue(new Error("SCORING_UNAVAILABLE"));
+
+        const server = createWorkflowsServer({
+            workflowRunRepository,
+            importJobFromUrl,
+            scoreJobFit,
+        });
+
+        await expect(
+            server.startImportJobAndScoreFitWorkflow({
+                sourceUrl: "https://example.com/jobs/123",
+                resumeProfileId: "resume-profile-1",
+            }),
+        ).rejects.toThrow("SCORING_UNAVAILABLE");
+
+        const runs = await server.listWorkflowRuns();
+
+        expect(runs).toHaveLength(1);
+        expect(runs[0]).toMatchObject({
+            workflowType: "import-job-and-score-fit",
+            status: "failed",
+            currentStepKey: "score-fit",
+            errorMessage: "SCORING_UNAVAILABLE",
+            retryCount: 1,
+        });
+
+        const workflowStatus = await server.getWorkflowRun({
+            workflowRunId: runs[0].id,
+        });
+
+        expect(workflowStatus?.workflowSteps).toHaveLength(2);
+        expect(workflowStatus?.workflowSteps[0]).toMatchObject({
+            stepKey: "import-job",
+            status: "succeeded",
+        });
+        expect(workflowStatus?.workflowSteps[1]).toMatchObject({
+            stepKey: "score-fit",
+            status: "failed",
+            attemptCount: 3,
+            errorMessage: "SCORING_UNAVAILABLE",
+        });
+    });
+
+    it("runs generate-application-materials workflow", async () => {
+        const workflowRunRepository = createInMemoryWorkflowRunRepository();
+
+        const importJobFromUrl = vi.fn();
+        const scoreJobFit = vi.fn();
+        const createTailoredResume = vi.fn().mockResolvedValue({
+            id: "tailored-resume-1",
+        });
+        const createCoverLetterDraft = vi.fn().mockResolvedValue({
+            id: "cover-letter-1",
+        });
+        const exportApplicationPacket = vi.fn().mockResolvedValue({
+            fileName: "application-packet-rp1-tailored-resume-1-cover-letter-1.pdf",
+        });
+
+        const server = createWorkflowsServer({
+            workflowRunRepository,
+            importJobFromUrl,
+            scoreJobFit,
+            createTailoredResume,
+            createCoverLetterDraft,
+            exportApplicationPacket,
+        });
+
+        const result = await server.startGenerateApplicationMaterialsWorkflow({
+            resumeProfileId: "rp1",
+            resumeVersionId: "rv1",
+            jobId: "job1",
+            format: "pdf",
+        });
+
+        expect(createTailoredResume).toHaveBeenCalledWith({
+            resumeProfileId: "rp1",
+            resumeVersionId: "rv1",
+            jobId: "job1",
+        });
+
+        expect(createCoverLetterDraft).toHaveBeenCalledWith({
+            resumeProfileId: "rp1",
+            jobId: "job1",
+        });
+
+        expect(exportApplicationPacket).toHaveBeenCalledWith({
+            resumeProfileId: "rp1",
+            resumeVersionId: "tailored-resume-1",
+            coverLetterDraftId: "cover-letter-1",
+            format: "pdf",
+        });
+
+        expect(result).toMatchObject({
+            id: expect.any(String),
+            workflowType: "generate-application-materials",
+            status: "succeeded",
+        });
+
+        const steps = await workflowRunRepository.listWorkflowStepsByRunId(
+            result!.id,
+        );
+
+        expect(steps).toHaveLength(3);
+        expect(steps[0]).toMatchObject({
+            stepKey: "generate-tailored-resume",
+            status: "succeeded",
+        });
+        expect(steps[1]).toMatchObject({
+            stepKey: "generate-cover-letter",
+            status: "succeeded",
+        });
+        expect(steps[2]).toMatchObject({
+            stepKey: "export-application-packet",
+            status: "succeeded",
+        });
+    });
+});

--- a/apps/job-coach-web/src/server/workflows.ts
+++ b/apps/job-coach-web/src/server/workflows.ts
@@ -1,0 +1,134 @@
+import {
+    createWorkflowQueue,
+    type WorkflowRunRepository,
+} from "@coach/core";
+import { createGenerateApplicationMaterialsWorkflow } from "./generate-application-materials-workflow";
+
+export function createWorkflowsServer(dependencies: {
+    workflowRunRepository: WorkflowRunRepository;
+    importJobFromUrl(input: { sourceUrl: string }): Promise<{ id: string }>;
+    scoreJobFit(input: {
+        jobId: string;
+        resumeProfileId: string;
+    }): Promise<unknown>;
+    createTailoredResume?(input: {
+        resumeProfileId: string;
+        resumeVersionId: string;
+        jobId: string;
+    }): Promise<{ id: string }>;
+    createCoverLetterDraft?(input: {
+        resumeProfileId: string;
+        jobId: string;
+    }): Promise<{ id: string }>;
+    exportApplicationPacket?(input: {
+        resumeProfileId: string;
+        resumeVersionId: string;
+        coverLetterDraftId: string;
+        format: "pdf" | "docx";
+    }): Promise<unknown>;
+}) {
+    const workflowQueue = createWorkflowQueue({
+        workflowRunRepository: dependencies.workflowRunRepository,
+    });
+
+    return {
+        async startImportJobAndScoreFitWorkflow(input: {
+            sourceUrl: string;
+            resumeProfileId: string;
+        }) {
+            const workflowRun =
+                await dependencies.workflowRunRepository.createWorkflowRun({
+                    workflowType: "import-job-and-score-fit",
+                    input: {
+                        sourceUrl: input.sourceUrl,
+                        resumeProfileId: input.resumeProfileId,
+                    },
+                    status: "queued",
+                });
+
+            let importedJobId: string | undefined;
+
+            await workflowQueue.enqueue({
+                workflowRunId: workflowRun.id,
+                steps: [
+                    {
+                        stepKey: "import-job",
+                        run: async () => {
+                            const job = await dependencies.importJobFromUrl({
+                                sourceUrl: input.sourceUrl,
+                            });
+
+                            importedJobId = job.id;
+                        },
+                    },
+                    {
+                        stepKey: "score-fit",
+                        run: async () => {
+                            if (!importedJobId) {
+                                throw new Error("MISSING_IMPORTED_JOB_ID");
+                            }
+
+                            await dependencies.scoreJobFit({
+                                jobId: importedJobId,
+                                resumeProfileId: input.resumeProfileId,
+                            });
+                        },
+                    },
+                ],
+            });
+
+            return dependencies.workflowRunRepository.getWorkflowRunById(
+                workflowRun.id,
+            );
+        },
+
+        async startGenerateApplicationMaterialsWorkflow(input: {
+            resumeProfileId: string;
+            resumeVersionId: string;
+            jobId: string;
+            format?: "pdf" | "docx";
+        }) {
+            if (
+                !dependencies.createTailoredResume ||
+                !dependencies.createCoverLetterDraft ||
+                !dependencies.exportApplicationPacket
+            ) {
+                throw new Error("APPLICATION_MATERIALS_WORKFLOW_NOT_CONFIGURED");
+            }
+
+            const workflow = createGenerateApplicationMaterialsWorkflow({
+                workflowRunRepository: dependencies.workflowRunRepository,
+                createTailoredResume: dependencies.createTailoredResume,
+                createCoverLetterDraft: dependencies.createCoverLetterDraft,
+                exportApplicationPacket: dependencies.exportApplicationPacket,
+            });
+
+            return workflow.start(input);
+        },
+
+        async getWorkflowRun(input: { workflowRunId: string }) {
+            const workflowRun =
+                await dependencies.workflowRunRepository.getWorkflowRunById(
+                    input.workflowRunId,
+                );
+
+            if (!workflowRun) {
+                return null;
+            }
+
+            const workflowSteps =
+                await dependencies.workflowRunRepository.listWorkflowStepsByRunId(
+                    workflowRun.id,
+                );
+
+            return {
+                workflowRun,
+                workflowSteps,
+            };
+        },
+
+        async listWorkflowRuns() {
+            return dependencies.workflowRunRepository.listWorkflowRuns();
+        },
+    };
+}

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,145 @@
+# Workflows
+
+The workflow layer coordinates multi-step operations using explicit persisted runs and steps.
+
+## Goals
+
+- make multi-step operations composable
+- preserve run history
+- surface step-by-step status
+- support retries for transient failures
+- avoid corrupting source data on retry
+
+## Data model
+
+### `workflow_runs`
+
+Tracks the overall workflow execution.
+
+Fields:
+
+- `id`
+- `workflow_type`
+- `status`
+- `input`
+- `current_step_key`
+- `error_message`
+- `retry_count`
+- `started_at`
+- `completed_at`
+- `created_at`
+
+### `workflow_steps`
+
+Tracks each step inside a workflow run.
+
+Fields:
+
+- `id`
+- `workflow_run_id`
+- `step_key`
+- `status`
+- `attempt_count`
+- `error_message`
+- `started_at`
+- `completed_at`
+- `created_at`
+
+## Execution model
+
+Workflows are defined as an ordered list of explicit steps.
+
+Current execution flow:
+
+1. create a `workflow_run`
+2. enqueue the run in the workflow queue
+3. process each step in order
+4. persist step state transitions
+5. retry failed steps up to the configured maximum
+6. mark the run as succeeded or failed
+
+## Queue model
+
+The current queue is intentionally simple.
+
+- in-process
+- FIFO
+- explicit step execution
+- bounded retry handling
+- no autonomous routing
+
+This keeps the orchestration layer narrow and understandable while still supporting background-style execution flow.
+
+## Retry behavior
+
+Retries are handled per step.
+
+- each step tracks `attempt_count`
+- transient failures can be retried
+- exhausted retries mark the step as failed
+- failed steps mark the workflow run as failed
+- failure details are persisted for debugging
+
+## Current workflow
+
+### `import-job-and-score-fit`
+
+Steps:
+
+1. `import-job`
+2. `score-fit`
+
+Input:
+
+- `sourceUrl`
+- `resumeProfileId`
+
+Behavior:
+
+- imports a job from URL
+- uses the imported job id to run fit scoring
+- records step history and failures
+- exposes final run and step state through API routes
+
+## Server layer
+
+The server layer composes orchestration with existing services.
+
+- `importJobFromUrl` from the jobs server
+- `scoreJobFit` from the evaluations server
+- DB-backed workflow repository for persisted run history
+
+## API
+
+### `POST /api/workflows`
+
+Starts a workflow.
+
+Currently supported:
+
+- `import-job-and-score-fit`
+
+### `GET /api/workflows`
+
+Lists workflow runs.
+
+### `GET /api/workflows/[workflowRunId]`
+
+Returns a workflow run and its steps.
+
+## Design constraints
+
+- workflows remain explicit and bounded
+- orchestration is built on persisted structured data
+- retries must not invent or overwrite unrelated data
+- debugging should rely on persisted state, not logs alone
+
+## Next evolution options
+
+Possible follow-up improvements:
+
+- durable out-of-process queue worker
+- delayed retry scheduling
+- additional workflow types
+- workflow restart from last failed step
+- UI for run history and step visibility

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,3 +21,7 @@ export * from "./exports/create-export";
 export * from "./resumes/generate-tailoring-suggestions";
 export * from "./exports/renderers";
 export * from "./exports/create-export-service";
+export * from "./workflows/types";
+export * from "./workflows/in-memory-workflow-run-repository";
+export * from "./workflows/run-workflow";
+export * from "./workflows/workflow-queue";

--- a/packages/core/src/workflows/in-memory-workflow-run-repository.test.ts
+++ b/packages/core/src/workflows/in-memory-workflow-run-repository.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { createInMemoryWorkflowRunRepository } from "./in-memory-workflow-run-repository";
+
+describe("createInMemoryWorkflowRunRepository", () => {
+    it("creates and updates workflow runs and steps", async () => {
+        const repository = createInMemoryWorkflowRunRepository();
+
+        const createdRun = await repository.createWorkflowRun({
+            workflowType: "import-job-and-score-fit",
+            input: {
+                jobUrl: "https://example.com/job/1",
+            },
+        });
+
+        expect(createdRun).toMatchObject({
+            id: expect.any(String),
+            workflowType: "import-job-and-score-fit",
+            status: "queued",
+            input: {
+                jobUrl: "https://example.com/job/1",
+            },
+            retryCount: 0,
+            createdAt: expect.any(Date),
+        });
+
+        const updatedRun = await repository.updateWorkflowRun({
+            workflowRunId: createdRun.id,
+            status: "running",
+            currentStepKey: "import-job",
+            startedAt: new Date("2026-04-22T22:00:00.000Z"),
+        });
+
+        expect(updatedRun).toMatchObject({
+            id: createdRun.id,
+            status: "running",
+            currentStepKey: "import-job",
+            startedAt: new Date("2026-04-22T22:00:00.000Z"),
+        });
+
+        const createdStep = await repository.createWorkflowStep({
+            workflowRunId: createdRun.id,
+            stepKey: "import-job",
+        });
+
+        expect(createdStep).toMatchObject({
+            id: expect.any(String),
+            workflowRunId: createdRun.id,
+            stepKey: "import-job",
+            status: "pending",
+            attemptCount: 0,
+            createdAt: expect.any(Date),
+        });
+
+        const updatedStep = await repository.updateWorkflowStep({
+            workflowStepId: createdStep.id,
+            status: "succeeded",
+            attemptCount: 1,
+            completedAt: new Date("2026-04-22T22:01:00.000Z"),
+        });
+
+        expect(updatedStep).toMatchObject({
+            id: createdStep.id,
+            status: "succeeded",
+            attemptCount: 1,
+            completedAt: new Date("2026-04-22T22:01:00.000Z"),
+        });
+
+        const fetchedRun = await repository.getWorkflowRunById(createdRun.id);
+
+        expect(fetchedRun).toMatchObject({
+            id: createdRun.id,
+            status: "running",
+            currentStepKey: "import-job",
+        });
+
+        const runs = await repository.listWorkflowRuns();
+        const steps = await repository.listWorkflowStepsByRunId(createdRun.id);
+
+        expect(runs).toHaveLength(1);
+        expect(steps).toHaveLength(1);
+        expect(steps[0]).toMatchObject({
+            id: createdStep.id,
+            stepKey: "import-job",
+        });
+    });
+});

--- a/packages/core/src/workflows/in-memory-workflow-run-repository.ts
+++ b/packages/core/src/workflows/in-memory-workflow-run-repository.ts
@@ -1,0 +1,135 @@
+import type {
+    CreateWorkflowRunInput,
+    CreateWorkflowStepInput,
+    UpdateWorkflowRunInput,
+    UpdateWorkflowStepInput,
+    WorkflowRun,
+    WorkflowRunRepository,
+    WorkflowStep,
+} from "./types";
+
+export function createInMemoryWorkflowRunRepository(): WorkflowRunRepository {
+    const workflowRuns = new Map<string, WorkflowRun>();
+    const workflowSteps = new Map<string, WorkflowStep>();
+
+    return {
+        async createWorkflowRun(input: CreateWorkflowRunInput) {
+            const workflowRun: WorkflowRun = {
+                id: crypto.randomUUID(),
+                workflowType: input.workflowType,
+                status: input.status ?? "queued",
+                input: input.input,
+                currentStepKey: input.currentStepKey,
+                errorMessage: input.errorMessage,
+                retryCount: input.retryCount ?? 0,
+                startedAt: input.startedAt,
+                completedAt: input.completedAt,
+                createdAt: new Date(),
+            };
+
+            workflowRuns.set(workflowRun.id, workflowRun);
+
+            return workflowRun;
+        },
+
+        async updateWorkflowRun(input: UpdateWorkflowRunInput) {
+            const existing = workflowRuns.get(input.workflowRunId);
+
+            if (!existing) {
+                return null;
+            }
+
+            const updated: WorkflowRun = {
+                ...existing,
+                status: input.status ?? existing.status,
+                currentStepKey:
+                    input.currentStepKey === undefined
+                        ? existing.currentStepKey
+                        : input.currentStepKey,
+                errorMessage:
+                    input.errorMessage === undefined
+                        ? existing.errorMessage
+                        : input.errorMessage,
+                retryCount: input.retryCount ?? existing.retryCount,
+                startedAt:
+                    input.startedAt === undefined
+                        ? existing.startedAt
+                        : input.startedAt,
+                completedAt:
+                    input.completedAt === undefined
+                        ? existing.completedAt
+                        : input.completedAt,
+            };
+
+            workflowRuns.set(updated.id, updated);
+
+            return updated;
+        },
+
+        async getWorkflowRunById(workflowRunId: string) {
+            return workflowRuns.get(workflowRunId) ?? null;
+        },
+
+        async listWorkflowRuns() {
+            return Array.from(workflowRuns.values()).sort((left, right) =>
+                left.createdAt.getTime() - right.createdAt.getTime(),
+            );
+        },
+
+        async createWorkflowStep(input: CreateWorkflowStepInput) {
+            const workflowStep: WorkflowStep = {
+                id: crypto.randomUUID(),
+                workflowRunId: input.workflowRunId,
+                stepKey: input.stepKey,
+                status: input.status ?? "pending",
+                attemptCount: input.attemptCount ?? 0,
+                errorMessage: input.errorMessage,
+                startedAt: input.startedAt,
+                completedAt: input.completedAt,
+                createdAt: new Date(),
+            };
+
+            workflowSteps.set(workflowStep.id, workflowStep);
+
+            return workflowStep;
+        },
+
+        async updateWorkflowStep(input: UpdateWorkflowStepInput) {
+            const existing = workflowSteps.get(input.workflowStepId);
+
+            if (!existing) {
+                return null;
+            }
+
+            const updated: WorkflowStep = {
+                ...existing,
+                status: input.status ?? existing.status,
+                attemptCount: input.attemptCount ?? existing.attemptCount,
+                errorMessage:
+                    input.errorMessage === undefined
+                        ? existing.errorMessage
+                        : input.errorMessage,
+                startedAt:
+                    input.startedAt === undefined
+                        ? existing.startedAt
+                        : input.startedAt,
+                completedAt:
+                    input.completedAt === undefined
+                        ? existing.completedAt
+                        : input.completedAt,
+            };
+
+            workflowSteps.set(updated.id, updated);
+
+            return updated;
+        },
+
+        async listWorkflowStepsByRunId(workflowRunId: string) {
+            return Array.from(workflowSteps.values())
+                .filter((step) => step.workflowRunId === workflowRunId)
+                .sort((left, right) =>
+                    left.createdAt.getTime() - right.createdAt.getTime(),
+                );
+        },
+    };
+}

--- a/packages/core/src/workflows/run-workflow.test.ts
+++ b/packages/core/src/workflows/run-workflow.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest";
+import { createInMemoryWorkflowRunRepository } from "./in-memory-workflow-run-repository";
+import { runWorkflow } from "./run-workflow";
+
+describe("runWorkflow", () => {
+    it("runs all workflow steps and marks the run as succeeded", async () => {
+        const workflowRunRepository = createInMemoryWorkflowRunRepository();
+
+        const workflowRun = await workflowRunRepository.createWorkflowRun({
+            workflowType: "import-job-and-score-fit",
+            input: {
+                jobUrl: "https://example.com/jobs/1",
+            },
+        });
+
+        const firstStep = vi.fn().mockResolvedValue(undefined);
+        const secondStep = vi.fn().mockResolvedValue(undefined);
+
+        await runWorkflow({
+            workflowRunRepository,
+            workflowRunId: workflowRun.id,
+            steps: [
+                {
+                    stepKey: "import-job",
+                    run: firstStep,
+                },
+                {
+                    stepKey: "score-fit",
+                    run: secondStep,
+                },
+            ],
+        });
+
+        expect(firstStep).toHaveBeenCalledWith({
+            workflowRunId: workflowRun.id,
+            attemptCount: 1,
+        });
+        expect(secondStep).toHaveBeenCalledWith({
+            workflowRunId: workflowRun.id,
+            attemptCount: 1,
+        });
+
+        const updatedRun = await workflowRunRepository.getWorkflowRunById(
+            workflowRun.id,
+        );
+        const steps = await workflowRunRepository.listWorkflowStepsByRunId(
+            workflowRun.id,
+        );
+
+        expect(updatedRun).toMatchObject({
+            id: workflowRun.id,
+            status: "succeeded",
+            errorMessage: undefined,
+            completedAt: expect.any(Date),
+        });
+
+        expect(steps).toHaveLength(2);
+        expect(steps[0]).toMatchObject({
+            stepKey: "import-job",
+            status: "succeeded",
+            attemptCount: 1,
+        });
+        expect(steps[1]).toMatchObject({
+            stepKey: "score-fit",
+            status: "succeeded",
+            attemptCount: 1,
+        });
+    });
+
+    it("retries a failing step and succeeds when a later attempt works", async () => {
+        const workflowRunRepository = createInMemoryWorkflowRunRepository();
+
+        const workflowRun = await workflowRunRepository.createWorkflowRun({
+            workflowType: "generate-tailored-resume",
+            input: {
+                resumeProfileId: "rp1",
+                resumeVersionId: "rv1",
+            },
+        });
+
+        const flakyStep = vi
+            .fn()
+            .mockRejectedValueOnce(new Error("temporary failure"))
+            .mockResolvedValueOnce(undefined);
+
+        await runWorkflow({
+            workflowRunRepository,
+            workflowRunId: workflowRun.id,
+            steps: [
+                {
+                    stepKey: "generate-tailored-resume",
+                    run: flakyStep,
+                },
+            ],
+            maxAttemptsPerStep: 2,
+        });
+
+        expect(flakyStep).toHaveBeenCalledTimes(2);
+
+        const updatedRun = await workflowRunRepository.getWorkflowRunById(
+            workflowRun.id,
+        );
+        const steps = await workflowRunRepository.listWorkflowStepsByRunId(
+            workflowRun.id,
+        );
+
+        expect(updatedRun).toMatchObject({
+            id: workflowRun.id,
+            status: "succeeded",
+        });
+
+        expect(steps).toHaveLength(1);
+        expect(steps[0]).toMatchObject({
+            stepKey: "generate-tailored-resume",
+            status: "succeeded",
+            attemptCount: 2,
+        });
+    });
+
+    it("marks the run as failed when retries are exhausted", async () => {
+        const workflowRunRepository = createInMemoryWorkflowRunRepository();
+
+        const workflowRun = await workflowRunRepository.createWorkflowRun({
+            workflowType: "generate-packet",
+            input: {
+                resumeProfileId: "rp1",
+                resumeVersionId: "rv1",
+                coverLetterDraftId: "cl1",
+            },
+        });
+
+        const failingStep = vi
+            .fn()
+            .mockRejectedValue(new Error("permanent failure"));
+
+        await expect(
+            runWorkflow({
+                workflowRunRepository,
+                workflowRunId: workflowRun.id,
+                steps: [
+                    {
+                        stepKey: "export-packet",
+                        run: failingStep,
+                    },
+                ],
+                maxAttemptsPerStep: 2,
+            }),
+        ).rejects.toThrow("permanent failure");
+
+        expect(failingStep).toHaveBeenCalledTimes(2);
+
+        const updatedRun = await workflowRunRepository.getWorkflowRunById(
+            workflowRun.id,
+        );
+        const steps = await workflowRunRepository.listWorkflowStepsByRunId(
+            workflowRun.id,
+        );
+
+        expect(updatedRun).toMatchObject({
+            id: workflowRun.id,
+            status: "failed",
+            currentStepKey: "export-packet",
+            errorMessage: "permanent failure",
+            retryCount: 1,
+            completedAt: expect.any(Date),
+        });
+
+        expect(steps).toHaveLength(1);
+        expect(steps[0]).toMatchObject({
+            stepKey: "export-packet",
+            status: "failed",
+            attemptCount: 2,
+            errorMessage: "permanent failure",
+        });
+    });
+});

--- a/packages/core/src/workflows/run-workflow.ts
+++ b/packages/core/src/workflows/run-workflow.ts
@@ -1,0 +1,116 @@
+import type { WorkflowRunRepository } from "./types";
+
+export type WorkflowStepDefinition = {
+    stepKey: string;
+    run(input: {
+        workflowRunId: string;
+        attemptCount: number;
+    }): Promise<void>;
+};
+
+export async function runWorkflow(input: {
+    workflowRunRepository: WorkflowRunRepository;
+    workflowRunId: string;
+    steps: WorkflowStepDefinition[];
+    maxAttemptsPerStep?: number;
+}) {
+    const maxAttemptsPerStep = input.maxAttemptsPerStep ?? 3;
+
+    await input.workflowRunRepository.updateWorkflowRun({
+        workflowRunId: input.workflowRunId,
+        status: "running",
+        startedAt: new Date(),
+    });
+
+    for (const definition of input.steps) {
+        const createdStep = await input.workflowRunRepository.createWorkflowStep({
+            workflowRunId: input.workflowRunId,
+            stepKey: definition.stepKey,
+            status: "pending",
+        });
+
+        await input.workflowRunRepository.updateWorkflowRun({
+            workflowRunId: input.workflowRunId,
+            currentStepKey: definition.stepKey,
+        });
+
+        let attemptCount = 0;
+        let lastError: unknown = undefined;
+
+        while (attemptCount < maxAttemptsPerStep) {
+            attemptCount += 1;
+
+            await input.workflowRunRepository.updateWorkflowStep({
+                workflowStepId: createdStep.id,
+                status: "running",
+                attemptCount,
+                errorMessage: undefined,
+                startedAt: new Date(),
+            });
+
+            try {
+                await definition.run({
+                    workflowRunId: input.workflowRunId,
+                    attemptCount,
+                });
+
+                await input.workflowRunRepository.updateWorkflowStep({
+                    workflowStepId: createdStep.id,
+                    status: "succeeded",
+                    attemptCount,
+                    completedAt: new Date(),
+                    errorMessage: undefined,
+                });
+
+                lastError = undefined;
+                break;
+            } catch (error) {
+                lastError = error;
+
+                const message =
+                    error instanceof Error ? error.message : "Unknown workflow step error";
+
+                await input.workflowRunRepository.updateWorkflowStep({
+                    workflowStepId: createdStep.id,
+                    status:
+                        attemptCount >= maxAttemptsPerStep ? "failed" : "pending",
+                    attemptCount,
+                    errorMessage: message,
+                    completedAt:
+                        attemptCount >= maxAttemptsPerStep ? new Date() : undefined,
+                });
+            }
+        }
+
+        if (lastError) {
+            const message =
+                lastError instanceof Error
+                    ? lastError.message
+                    : "Unknown workflow step error";
+
+            const existingRun =
+                await input.workflowRunRepository.getWorkflowRunById(
+                    input.workflowRunId,
+                );
+
+            await input.workflowRunRepository.updateWorkflowRun({
+                workflowRunId: input.workflowRunId,
+                status: "failed",
+                currentStepKey: definition.stepKey,
+                errorMessage: message,
+                retryCount: (existingRun?.retryCount ?? 0) + 1,
+                completedAt: new Date(),
+            });
+
+            throw lastError;
+        }
+    }
+
+    await input.workflowRunRepository.updateWorkflowRun({
+        workflowRunId: input.workflowRunId,
+        status: "succeeded",
+        currentStepKey: undefined,
+        errorMessage: undefined,
+        completedAt: new Date(),
+    });
+}

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -1,0 +1,94 @@
+export const WORKFLOW_RUN_STATUSES = [
+    "queued",
+    "running",
+    "succeeded",
+    "failed",
+    "cancelled",
+] as const;
+
+export type WorkflowRunStatus = (typeof WORKFLOW_RUN_STATUSES)[number];
+
+export const WORKFLOW_STEP_STATUSES = [
+    "pending",
+    "running",
+    "succeeded",
+    "failed",
+    "skipped",
+] as const;
+
+export type WorkflowStepStatus = (typeof WORKFLOW_STEP_STATUSES)[number];
+
+export interface WorkflowRun {
+    id: string;
+    workflowType: string;
+    status: WorkflowRunStatus;
+    input: Record<string, unknown>;
+    currentStepKey?: string;
+    errorMessage?: string;
+    retryCount: number;
+    startedAt?: Date;
+    completedAt?: Date;
+    createdAt: Date;
+}
+
+export interface WorkflowStep {
+    id: string;
+    workflowRunId: string;
+    stepKey: string;
+    status: WorkflowStepStatus;
+    attemptCount: number;
+    errorMessage?: string;
+    startedAt?: Date;
+    completedAt?: Date;
+    createdAt: Date;
+}
+
+export interface CreateWorkflowRunInput {
+    workflowType: string;
+    input: Record<string, unknown>;
+    status?: WorkflowRunStatus;
+    currentStepKey?: string;
+    errorMessage?: string;
+    retryCount?: number;
+    startedAt?: Date;
+    completedAt?: Date;
+}
+
+export interface UpdateWorkflowRunInput {
+    workflowRunId: string;
+    status?: WorkflowRunStatus;
+    currentStepKey?: string;
+    errorMessage?: string;
+    retryCount?: number;
+    startedAt?: Date;
+    completedAt?: Date;
+}
+
+export interface CreateWorkflowStepInput {
+    workflowRunId: string;
+    stepKey: string;
+    status?: WorkflowStepStatus;
+    attemptCount?: number;
+    errorMessage?: string;
+    startedAt?: Date;
+    completedAt?: Date;
+}
+
+export interface UpdateWorkflowStepInput {
+    workflowStepId: string;
+    status?: WorkflowStepStatus;
+    attemptCount?: number;
+    errorMessage?: string;
+    startedAt?: Date;
+    completedAt?: Date;
+}
+
+export interface WorkflowRunRepository {
+    createWorkflowRun(input: CreateWorkflowRunInput): Promise<WorkflowRun>;
+    updateWorkflowRun(input: UpdateWorkflowRunInput): Promise<WorkflowRun | null>;
+    getWorkflowRunById(workflowRunId: string): Promise<WorkflowRun | null>;
+    listWorkflowRuns(): Promise<WorkflowRun[]>;
+    createWorkflowStep(input: CreateWorkflowStepInput): Promise<WorkflowStep>;
+    updateWorkflowStep(input: UpdateWorkflowStepInput): Promise<WorkflowStep | null>;
+    listWorkflowStepsByRunId(workflowRunId: string): Promise<WorkflowStep[]>;
+}

--- a/packages/core/src/workflows/workflow-queue.test.ts
+++ b/packages/core/src/workflows/workflow-queue.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import { createInMemoryWorkflowRunRepository } from "./in-memory-workflow-run-repository";
+import { createWorkflowQueue } from "./workflow-queue";
+
+describe("createWorkflowQueue", () => {
+    it("processes queued jobs in order", async () => {
+        const repository = createInMemoryWorkflowRunRepository();
+        const queue = createWorkflowQueue({
+            workflowRunRepository: repository,
+        });
+
+        const runOne = await repository.createWorkflowRun({
+            workflowType: "workflow-one",
+            input: {},
+        });
+
+        const runTwo = await repository.createWorkflowRun({
+            workflowType: "workflow-two",
+            input: {},
+        });
+
+        const calls: string[] = [];
+
+        await queue.enqueue({
+            workflowRunId: runOne.id,
+            steps: [
+                {
+                    stepKey: "step-one",
+                    run: async () => {
+                        calls.push("run-one");
+                    },
+                },
+            ],
+        });
+
+        await queue.enqueue({
+            workflowRunId: runTwo.id,
+            steps: [
+                {
+                    stepKey: "step-two",
+                    run: async () => {
+                        calls.push("run-two");
+                    },
+                },
+            ],
+        });
+
+        expect(calls).toEqual(["run-one", "run-two"]);
+
+        const updatedRunOne = await repository.getWorkflowRunById(runOne.id);
+        const updatedRunTwo = await repository.getWorkflowRunById(runTwo.id);
+
+        expect(updatedRunOne).toMatchObject({
+            status: "succeeded",
+        });
+        expect(updatedRunTwo).toMatchObject({
+            status: "succeeded",
+        });
+        expect(queue.getPendingCount()).toBe(0);
+        expect(queue.isProcessing()).toBe(false);
+    });
+
+    it("marks a run as failed when a queued job step exhausts retries", async () => {
+        const repository = createInMemoryWorkflowRunRepository();
+        const queue = createWorkflowQueue({
+            workflowRunRepository: repository,
+        });
+
+        const run = await repository.createWorkflowRun({
+            workflowType: "workflow-failure",
+            input: {},
+        });
+
+        const failingStep = vi
+            .fn()
+            .mockRejectedValue(new Error("QUEUE_STEP_FAILED"));
+
+        await expect(
+            queue.enqueue({
+                workflowRunId: run.id,
+                steps: [
+                    {
+                        stepKey: "always-fails",
+                        run: failingStep,
+                    },
+                ],
+                maxAttemptsPerStep: 2,
+            }),
+        ).rejects.toThrow("QUEUE_STEP_FAILED");
+
+        expect(failingStep).toHaveBeenCalledTimes(2);
+
+        const updatedRun = await repository.getWorkflowRunById(run.id);
+        const steps = await repository.listWorkflowStepsByRunId(run.id);
+
+        expect(updatedRun).toMatchObject({
+            status: "failed",
+            currentStepKey: "always-fails",
+            errorMessage: "QUEUE_STEP_FAILED",
+            retryCount: 1,
+        });
+
+        expect(steps).toHaveLength(1);
+        expect(steps[0]).toMatchObject({
+            stepKey: "always-fails",
+            status: "failed",
+            attemptCount: 2,
+        });
+    });
+});

--- a/packages/core/src/workflows/workflow-queue.ts
+++ b/packages/core/src/workflows/workflow-queue.ts
@@ -1,0 +1,60 @@
+import type { WorkflowRunRepository } from "./types";
+import { runWorkflow, type WorkflowStepDefinition } from "./run-workflow";
+
+export interface WorkflowQueueJob {
+    workflowRunId: string;
+    steps: WorkflowStepDefinition[];
+    maxAttemptsPerStep?: number;
+}
+
+export function createWorkflowQueue(dependencies: {
+    workflowRunRepository: WorkflowRunRepository;
+}) {
+    const jobs: WorkflowQueueJob[] = [];
+    let isProcessing = false;
+
+    async function processNext() {
+        if (isProcessing) {
+            return;
+        }
+
+        const nextJob = jobs.shift();
+
+        if (!nextJob) {
+            return;
+        }
+
+        isProcessing = true;
+
+        try {
+            await runWorkflow({
+                workflowRunRepository: dependencies.workflowRunRepository,
+                workflowRunId: nextJob.workflowRunId,
+                steps: nextJob.steps,
+                maxAttemptsPerStep: nextJob.maxAttemptsPerStep,
+            });
+        } finally {
+            isProcessing = false;
+
+            if (jobs.length > 0) {
+                await processNext();
+            }
+        }
+    }
+
+    return {
+        async enqueue(job: WorkflowQueueJob) {
+            jobs.push(job);
+
+            await processNext();
+        },
+
+        getPendingCount() {
+            return jobs.length;
+        },
+
+        isProcessing() {
+            return isProcessing;
+        },
+    };
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -12,5 +12,6 @@ export * from "./cover-letter-drafts/create-db-create-cover-letter-draft";
 export * from "./cover-letter-drafts/create-db-get-cover-letter-draft";
 
 export * from "./exported-artifacts/db-exported-artifact-repository";
+export * from "./workflows/db-workflow-run-repository";
 
 export * from "./supabase/create-server-client";

--- a/packages/db/src/migrations/0009_create_workflow_runs.sql
+++ b/packages/db/src/migrations/0009_create_workflow_runs.sql
@@ -1,0 +1,28 @@
+create table if not exists workflow_runs (
+    id uuid primary key default gen_random_uuid(),
+    workflow_type text not null,
+    status text not null,
+    current_step_key text,
+    input_json jsonb not null,
+    error_message text,
+    retry_count integer not null default 0,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+create table if not exists workflow_steps (
+    id uuid primary key default gen_random_uuid(),
+    workflow_run_id uuid not null references workflow_runs(id) on delete cascade,
+    step_key text not null,
+    status text not null,
+    attempt_count integer not null default 0,
+    error_message text,
+    started_at timestamptz,
+    completed_at timestamptz
+);
+
+create index if not exists workflow_runs_status_idx
+    on workflow_runs(status);
+
+create index if not exists workflow_steps_run_id_idx
+    on workflow_steps(workflow_run_id);

--- a/packages/db/src/migrations/0009_create_workflow_runs_and_steps.sql
+++ b/packages/db/src/migrations/0009_create_workflow_runs_and_steps.sql
@@ -1,0 +1,30 @@
+create table if not exists workflow_runs (
+    id uuid primary key default gen_random_uuid(),
+    workflow_type text not null,
+    status text not null,
+    input jsonb not null,
+    current_step_key text null,
+    error_message text null,
+    retry_count integer not null default 0,
+    started_at timestamptz null,
+    completed_at timestamptz null,
+    created_at timestamptz not null default now()
+);
+
+create table if not exists workflow_steps (
+    id uuid primary key default gen_random_uuid(),
+    workflow_run_id uuid not null references workflow_runs(id) on delete cascade,
+    step_key text not null,
+    status text not null,
+    attempt_count integer not null default 0,
+    error_message text null,
+    started_at timestamptz null,
+    completed_at timestamptz null,
+    created_at timestamptz not null default now()
+);
+
+create index if not exists workflow_runs_created_at_idx
+    on workflow_runs (created_at);
+
+create index if not exists workflow_steps_workflow_run_id_idx
+    on workflow_steps (workflow_run_id, created_at);

--- a/packages/db/src/workflows/db-workflow-run-repository.test.ts
+++ b/packages/db/src/workflows/db-workflow-run-repository.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from "vitest";
+import { createDbWorkflowRunRepository } from "./db-workflow-run-repository";
+
+describe("createDbWorkflowRunRepository", () => {
+    it("creates and updates workflow runs and steps", async () => {
+        const workflowRuns = new Map<
+            string,
+            {
+                id: string;
+                workflow_type: string;
+                status: string;
+                input: Record<string, unknown>;
+                current_step_key: string | null;
+                error_message: string | null;
+                retry_count: number;
+                started_at: Date | null;
+                completed_at: Date | null;
+                created_at: Date;
+            }
+        >();
+
+        const workflowSteps = new Map<
+            string,
+            {
+                id: string;
+                workflow_run_id: string;
+                step_key: string;
+                status: string;
+                attempt_count: number;
+                error_message: string | null;
+                started_at: Date | null;
+                completed_at: Date | null;
+                created_at: Date;
+            }
+        >();
+
+        const db = {
+            insertInto(table: string) {
+                if (table === "workflow_runs") {
+                    return {
+                        values(input: any) {
+                            const row = {
+                                id: crypto.randomUUID(),
+                                ...input,
+                                created_at: new Date(),
+                            };
+
+                            workflowRuns.set(row.id, row);
+
+                            return {
+                                returningAll() {
+                                    return {
+                                        executeTakeFirstOrThrow: async () => row,
+                                    };
+                                },
+                            };
+                        },
+                    };
+                }
+
+                expect(table).toBe("workflow_steps");
+
+                return {
+                    values(input: any) {
+                        const row = {
+                            id: crypto.randomUUID(),
+                            ...input,
+                            created_at: new Date(),
+                        };
+
+                        workflowSteps.set(row.id, row);
+
+                        return {
+                            returningAll() {
+                                return {
+                                    executeTakeFirstOrThrow: async () => row,
+                                };
+                            },
+                        };
+                    },
+                };
+            },
+
+            updateTable(table: string) {
+                if (table === "workflow_runs") {
+                    return {
+                        set(input: Record<string, unknown>) {
+                            return {
+                                where(column: string, operator: string, value: string) {
+                                    expect(column).toBe("id");
+                                    expect(operator).toBe("=");
+
+                                    return {
+                                        returningAll() {
+                                            return {
+                                                executeTakeFirst: async () => {
+                                                    const existing =
+                                                        workflowRuns.get(value);
+
+                                                    if (!existing) {
+                                                        return undefined;
+                                                    }
+
+                                                    const updated = {
+                                                        ...existing,
+                                                        ...input,
+                                                    };
+
+                                                    workflowRuns.set(value, updated);
+
+                                                    return updated;
+                                                },
+                                            };
+                                        },
+                                    };
+                                },
+                            };
+                        },
+                    };
+                }
+
+                expect(table).toBe("workflow_steps");
+
+                return {
+                    set(input: Record<string, unknown>) {
+                        return {
+                            where(column: string, operator: string, value: string) {
+                                expect(column).toBe("id");
+                                expect(operator).toBe("=");
+
+                                return {
+                                    returningAll() {
+                                        return {
+                                            executeTakeFirst: async () => {
+                                                const existing =
+                                                    workflowSteps.get(value);
+
+                                                if (!existing) {
+                                                    return undefined;
+                                                }
+
+                                                const updated = {
+                                                    ...existing,
+                                                    ...input,
+                                                };
+
+                                                workflowSteps.set(value, updated);
+
+                                                return updated;
+                                            },
+                                        };
+                                    },
+                                };
+                            },
+                        };
+                    },
+                };
+            },
+
+            selectFrom(table: string) {
+                if (table === "workflow_runs") {
+                    return {
+                        selectAll() {
+                            return {
+                                where(column: string, operator: string, value: string) {
+                                    expect(column).toBe("id");
+                                    expect(operator).toBe("=");
+
+                                    return {
+                                        executeTakeFirst: async () =>
+                                            workflowRuns.get(value) ?? undefined,
+                                    };
+                                },
+                                orderBy(column: string, direction: string) {
+                                    expect(column).toBe("created_at");
+                                    expect(direction).toBe("asc");
+
+                                    return {
+                                        execute: async () =>
+                                            Array.from(workflowRuns.values()),
+                                    };
+                                },
+                            };
+                        },
+                    };
+                }
+
+                expect(table).toBe("workflow_steps");
+
+                return {
+                    selectAll() {
+                        return {
+                            where(column: string, operator: string, value: string) {
+                                expect(column).toBe("workflow_run_id");
+                                expect(operator).toBe("=");
+
+                                return {
+                                    orderBy(orderColumn: string, direction: string) {
+                                        expect(orderColumn).toBe("created_at");
+                                        expect(direction).toBe("asc");
+
+                                        return {
+                                            execute: async () =>
+                                                Array.from(workflowSteps.values()).filter(
+                                                    (step) =>
+                                                        step.workflow_run_id === value,
+                                                ),
+                                        };
+                                    },
+                                };
+                            },
+                        };
+                    },
+                };
+            },
+        };
+
+        const repository = createDbWorkflowRunRepository({ db });
+
+        const createdRun = await repository.createWorkflowRun({
+            workflowType: "import-job-and-score-fit",
+            input: {
+                jobUrl: "https://example.com/job/1",
+            },
+        });
+
+        expect(createdRun).toMatchObject({
+            id: expect.any(String),
+            workflowType: "import-job-and-score-fit",
+            status: "queued",
+            retryCount: 0,
+            createdAt: expect.any(Date),
+        });
+
+        const updatedRun = await repository.updateWorkflowRun({
+            workflowRunId: createdRun.id,
+            status: "running",
+            currentStepKey: "import-job",
+            retryCount: 1,
+        });
+
+        expect(updatedRun).toMatchObject({
+            id: createdRun.id,
+            status: "running",
+            currentStepKey: "import-job",
+            retryCount: 1,
+        });
+
+        const fetchedRun = await repository.getWorkflowRunById(createdRun.id);
+
+        expect(fetchedRun).toMatchObject({
+            id: createdRun.id,
+            status: "running",
+            currentStepKey: "import-job",
+        });
+
+        const createdStep = await repository.createWorkflowStep({
+            workflowRunId: createdRun.id,
+            stepKey: "import-job",
+        });
+
+        expect(createdStep).toMatchObject({
+            id: expect.any(String),
+            workflowRunId: createdRun.id,
+            stepKey: "import-job",
+            status: "pending",
+            attemptCount: 0,
+            createdAt: expect.any(Date),
+        });
+
+        const updatedStep = await repository.updateWorkflowStep({
+            workflowStepId: createdStep.id,
+            status: "failed",
+            attemptCount: 1,
+            errorMessage: "temporary failure",
+        });
+
+        expect(updatedStep).toMatchObject({
+            id: createdStep.id,
+            status: "failed",
+            attemptCount: 1,
+            errorMessage: "temporary failure",
+        });
+
+        const runs = await repository.listWorkflowRuns();
+        const steps = await repository.listWorkflowStepsByRunId(createdRun.id);
+
+        expect(runs).toHaveLength(1);
+        expect(steps).toHaveLength(1);
+        expect(steps[0]).toMatchObject({
+            id: createdStep.id,
+            stepKey: "import-job",
+            status: "failed",
+        });
+    });
+});

--- a/packages/db/src/workflows/db-workflow-run-repository.ts
+++ b/packages/db/src/workflows/db-workflow-run-repository.ts
@@ -1,0 +1,192 @@
+import type {
+    CreateWorkflowRunInput,
+    CreateWorkflowStepInput,
+    UpdateWorkflowRunInput,
+    UpdateWorkflowStepInput,
+    WorkflowRun,
+    WorkflowRunRepository,
+    WorkflowStep,
+} from "@coach/core";
+
+type WorkflowRunRow = {
+    id: string;
+    workflow_type: string;
+    status: WorkflowRun["status"];
+    input: Record<string, unknown>;
+    current_step_key: string | null;
+    error_message: string | null;
+    retry_count: number;
+    started_at: string | Date | null;
+    completed_at: string | Date | null;
+    created_at: string | Date;
+};
+
+type WorkflowStepRow = {
+    id: string;
+    workflow_run_id: string;
+    step_key: string;
+    status: WorkflowStep["status"];
+    attempt_count: number;
+    error_message: string | null;
+    started_at: string | Date | null;
+    completed_at: string | Date | null;
+    created_at: string | Date;
+};
+
+function mapWorkflowRun(row: WorkflowRunRow): WorkflowRun {
+    return {
+        id: row.id,
+        workflowType: row.workflow_type,
+        status: row.status,
+        input: row.input,
+        currentStepKey: row.current_step_key ?? undefined,
+        errorMessage: row.error_message ?? undefined,
+        retryCount: row.retry_count,
+        startedAt: row.started_at ? new Date(row.started_at) : undefined,
+        completedAt: row.completed_at ? new Date(row.completed_at) : undefined,
+        createdAt: new Date(row.created_at),
+    };
+}
+
+function mapWorkflowStep(row: WorkflowStepRow): WorkflowStep {
+    return {
+        id: row.id,
+        workflowRunId: row.workflow_run_id,
+        stepKey: row.step_key,
+        status: row.status,
+        attemptCount: row.attempt_count,
+        errorMessage: row.error_message ?? undefined,
+        startedAt: row.started_at ? new Date(row.started_at) : undefined,
+        completedAt: row.completed_at ? new Date(row.completed_at) : undefined,
+        createdAt: new Date(row.created_at),
+    };
+}
+
+export function createDbWorkflowRunRepository({
+    db,
+}: {
+    db: any;
+}): WorkflowRunRepository {
+    return {
+        async createWorkflowRun(input: CreateWorkflowRunInput) {
+            const row = await db
+                .insertInto("workflow_runs")
+                .values({
+                    workflow_type: input.workflowType,
+                    status: input.status ?? "queued",
+                    input: input.input,
+                    current_step_key: input.currentStepKey ?? null,
+                    error_message: input.errorMessage ?? null,
+                    retry_count: input.retryCount ?? 0,
+                    started_at: input.startedAt ?? null,
+                    completed_at: input.completedAt ?? null,
+                })
+                .returningAll()
+                .executeTakeFirstOrThrow();
+
+            return mapWorkflowRun(row);
+        },
+
+        async updateWorkflowRun(input: UpdateWorkflowRunInput) {
+            const row = await db
+                .updateTable("workflow_runs")
+                .set({
+                    ...(input.status !== undefined ? { status: input.status } : {}),
+                    ...(input.currentStepKey !== undefined
+                        ? { current_step_key: input.currentStepKey ?? null }
+                        : {}),
+                    ...(input.errorMessage !== undefined
+                        ? { error_message: input.errorMessage ?? null }
+                        : {}),
+                    ...(input.retryCount !== undefined
+                        ? { retry_count: input.retryCount }
+                        : {}),
+                    ...(input.startedAt !== undefined
+                        ? { started_at: input.startedAt ?? null }
+                        : {}),
+                    ...(input.completedAt !== undefined
+                        ? { completed_at: input.completedAt ?? null }
+                        : {}),
+                })
+                .where("id", "=", input.workflowRunId)
+                .returningAll()
+                .executeTakeFirst();
+
+            return row ? mapWorkflowRun(row) : null;
+        },
+
+        async getWorkflowRunById(workflowRunId: string) {
+            const row = await db
+                .selectFrom("workflow_runs")
+                .selectAll()
+                .where("id", "=", workflowRunId)
+                .executeTakeFirst();
+
+            return row ? mapWorkflowRun(row) : null;
+        },
+
+        async listWorkflowRuns() {
+            const rows = await db
+                .selectFrom("workflow_runs")
+                .selectAll()
+                .orderBy("created_at", "asc")
+                .execute();
+
+            return rows.map(mapWorkflowRun);
+        },
+
+        async createWorkflowStep(input: CreateWorkflowStepInput) {
+            const row = await db
+                .insertInto("workflow_steps")
+                .values({
+                    workflow_run_id: input.workflowRunId,
+                    step_key: input.stepKey,
+                    status: input.status ?? "pending",
+                    attempt_count: input.attemptCount ?? 0,
+                    error_message: input.errorMessage ?? null,
+                    started_at: input.startedAt ?? null,
+                    completed_at: input.completedAt ?? null,
+                })
+                .returningAll()
+                .executeTakeFirstOrThrow();
+
+            return mapWorkflowStep(row);
+        },
+
+        async updateWorkflowStep(input: UpdateWorkflowStepInput) {
+            const row = await db
+                .updateTable("workflow_steps")
+                .set({
+                    ...(input.status !== undefined ? { status: input.status } : {}),
+                    ...(input.attemptCount !== undefined
+                        ? { attempt_count: input.attemptCount }
+                        : {}),
+                    ...(input.errorMessage !== undefined
+                        ? { error_message: input.errorMessage ?? null }
+                        : {}),
+                    ...(input.startedAt !== undefined
+                        ? { started_at: input.startedAt ?? null }
+                        : {}),
+                    ...(input.completedAt !== undefined
+                        ? { completed_at: input.completedAt ?? null }
+                        : {}),
+                })
+                .where("id", "=", input.workflowStepId)
+                .returningAll()
+                .executeTakeFirst();
+
+            return row ? mapWorkflowStep(row) : null;
+        },
+
+        async listWorkflowStepsByRunId(workflowRunId: string) {
+            const rows = await db
+                .selectFrom("workflow_steps")
+                .selectAll()
+                .where("workflow_run_id", "=", workflowRunId)
+                .orderBy("created_at", "asc")
+                .execute();
+
+            return rows.map(mapWorkflowStep);
+        },
+    };
+}


### PR DESCRIPTION
## Summary

Implements Stage 9 workflow orchestration for multi-step job coach operations.

## What changed

- added persisted workflow run and step tracking
- added workflow run/step repository support
- added workflow runner with retry and failure handling
- added a simple in-process workflow queue
- added import-job-and-score-fit workflow
- added generate-application-materials workflow
- added workflow API endpoints for:
  - listing runs
  - starting workflows
  - fetching run details
- added workflow architecture documentation

## Behavior

- multi-step operations are now composed as explicit workflows
- each workflow records run history and per-step status
- failed steps persist error details
- retries are bounded and tracked
- workflow state is queryable through API routes

## Testing

- added core workflow repository tests
- added core workflow runner tests
- added queue tests
- added server workflow tests
- added workflow API route tests
- full db and web test suites pass
- db and web typecheck pass

## Notes

- queue implementation is intentionally simple and bounded
- workflow orchestration remains explicit rather than agentic
- architecture leaves room for a later durable/out-of-process worker