### PR TITLE
Stage 17: match Gmail messages to jobs and extract updates

### DIFF
--- a/packages/core/src/integrations/create-gmail-candidate-update.test.ts
+++ b/packages/core/src/integrations/create-gmail-candidate-update.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { createGmailCandidateUpdate } from "./create-gmail-candidate-update";
+
+describe("createGmailCandidateUpdate", () => {
+    it("creates a candidate update when a message matches a job and contains a supported signal", () => {
+        const result = createGmailCandidateUpdate({
+            message: {
+                id: "msg-1",
+                subject: "Interview with Acme",
+                from: "recruiter@acme.com",
+                snippet: "We would like to schedule an interview with the team.",
+                receivedAt: "2026-04-23T10:00:00.000Z",
+            },
+            jobs: [
+                {
+                    id: "job-1",
+                    company: "Acme",
+                    title: "Engineer",
+                    sourceUrl: "",
+                    sourceText: "",
+                    status: "applied",
+                    createdAt: "",
+                    updatedAt: "",
+                },
+            ],
+        });
+
+        expect(result).toMatchObject({
+            jobId: "job-1",
+            messageId: "msg-1",
+            status: "interviewing",
+            note: "We would like to schedule an interview with the team.",
+        });
+    });
+
+    it("returns null when the message does not match a job", () => {
+        const result = createGmailCandidateUpdate({
+            message: {
+                id: "msg-1",
+                subject: "Interview with UnknownCo",
+                from: "recruiter@unknown.com",
+                snippet: "We would like to schedule an interview with the team.",
+                receivedAt: "2026-04-23T10:00:00.000Z",
+            },
+            jobs: [],
+        });
+
+        expect(result).toBeNull();
+    });
+
+    it("returns null when the message matches a job but has no supported signal", () => {
+        const result = createGmailCandidateUpdate({
+            message: {
+                id: "msg-1",
+                subject: "Thanks for applying to Acme",
+                from: "recruiter@acme.com",
+                snippet: "We received your application.",
+                receivedAt: "2026-04-23T10:00:00.000Z",
+            },
+            jobs: [
+                {
+                    id: "job-1",
+                    company: "Acme",
+                    title: "Engineer",
+                    sourceUrl: "",
+                    sourceText: "",
+                    status: "applied",
+                    createdAt: "",
+                    updatedAt: "",
+                },
+            ],
+        });
+
+        expect(result).toBeNull();
+    });
+});

--- a/packages/core/src/integrations/create-gmail-candidate-update.ts
+++ b/packages/core/src/integrations/create-gmail-candidate-update.ts
@@ -1,0 +1,42 @@
+import type { JobRecord } from "../jobs/types";
+import type { GmailMessage } from "./gmail-message-types";
+import { extractGmailUpdate } from "./extract-gmail-update";
+import { matchGmailMessageToJob } from "./match-gmail-message-to-job";
+
+export function createGmailCandidateUpdate({
+    message,
+    jobs,
+}: {
+    message: GmailMessage;
+    jobs: JobRecord[];
+}): {
+    jobId: string;
+    messageId: string;
+    status: "interviewing" | "rejected";
+    note: string;
+} | null {
+    const matchedJob = matchGmailMessageToJob({
+        message,
+        jobs,
+    });
+
+    if (!matchedJob) {
+        return null;
+    }
+
+    const extractedUpdate = extractGmailUpdate({
+        subject: message.subject,
+        snippet: message.snippet,
+    });
+
+    if (!extractedUpdate) {
+        return null;
+    }
+
+    return {
+        jobId: matchedJob.jobId,
+        messageId: message.id,
+        status: extractedUpdate.status,
+        note: extractedUpdate.note,
+    };
+}

--- a/packages/core/src/integrations/extract-gmail-update.test.ts
+++ b/packages/core/src/integrations/extract-gmail-update.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { extractGmailUpdate } from "./extract-gmail-update";
+
+describe("extractGmailUpdate", () => {
+    it("extracts an interview signal", () => {
+        const result = extractGmailUpdate({
+            subject: "Interview with Acme",
+            snippet: "We would like to schedule an interview with the team.",
+        });
+
+        expect(result).toMatchObject({
+            status: "interviewing",
+            note: "We would like to schedule an interview with the team.",
+        });
+    });
+
+    it("extracts a rejection signal", () => {
+        const result = extractGmailUpdate({
+            subject: "Update on your application",
+            snippet: "We have decided not to move forward at this time.",
+        });
+
+        expect(result).toMatchObject({
+            status: "rejected",
+            note: "We have decided not to move forward at this time.",
+        });
+    });
+
+    it("returns null when no supported signal is found", () => {
+        const result = extractGmailUpdate({
+            subject: "Thanks for applying",
+            snippet: "We received your application.",
+        });
+
+        expect(result).toBeNull();
+    });
+});

--- a/packages/core/src/integrations/extract-gmail-update.ts
+++ b/packages/core/src/integrations/extract-gmail-update.ts
@@ -1,0 +1,29 @@
+export function extractGmailUpdate({
+    subject,
+    snippet,
+}: {
+    subject: string;
+    snippet: string;
+}): { status: "interviewing" | "rejected"; note: string } | null {
+    const normalizedText = `${subject} ${snippet}`.toLowerCase();
+
+    if (normalizedText.includes("interview")) {
+        return {
+            status: "interviewing",
+            note: snippet,
+        };
+    }
+
+    if (
+        normalizedText.includes("not to move forward") ||
+        normalizedText.includes("rejected") ||
+        normalizedText.includes("unfortunately")
+    ) {
+        return {
+            status: "rejected",
+            note: snippet,
+        };
+    }
+
+    return null;
+}

--- a/packages/core/src/integrations/gmail-message-types.ts
+++ b/packages/core/src/integrations/gmail-message-types.ts
@@ -1,0 +1,7 @@
+export type GmailMessage = {
+    id: string;
+    subject: string;
+    from: string;
+    snippet: string;
+    receivedAt: string;
+};

--- a/packages/core/src/integrations/match-gmail-message-to-job.test.ts
+++ b/packages/core/src/integrations/match-gmail-message-to-job.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { matchGmailMessageToJob } from "./match-gmail-message-to-job";
+
+describe("matchGmailMessageToJob", () => {
+    it("matches a message to a job by company name in subject", () => {
+        const result = matchGmailMessageToJob({
+            message: {
+                id: "msg-1",
+                subject: "Interview with Acme",
+                from: "recruiter@acme.com",
+                snippet: "We would like to schedule an interview",
+                receivedAt: "2026-04-23T10:00:00.000Z",
+            },
+            jobs: [
+                {
+                    id: "job-1",
+                    company: "Acme",
+                    title: "Engineer",
+                    sourceUrl: "",
+                    sourceText: "",
+                    status: "applied",
+                    createdAt: "",
+                    updatedAt: "",
+                },
+            ],
+        });
+
+        expect(result?.jobId).toBe("job-1");
+    });
+
+    it("returns null when no job matches", () => {
+        const result = matchGmailMessageToJob({
+            message: {
+                id: "msg-1",
+                subject: "Interview with UnknownCo",
+                from: "recruiter@unknown.com",
+                snippet: "",
+                receivedAt: "",
+            },
+            jobs: [],
+        });
+
+        expect(result).toBeNull();
+    });
+});

--- a/packages/core/src/integrations/match-gmail-message-to-job.ts
+++ b/packages/core/src/integrations/match-gmail-message-to-job.ts
@@ -1,0 +1,24 @@
+import type { JobRecord } from "../jobs/types";
+import type { GmailMessage } from "./gmail-message-types";
+
+export function matchGmailMessageToJob({
+    message,
+    jobs,
+}: {
+    message: GmailMessage;
+    jobs: JobRecord[];
+}): { jobId: string } | null {
+    const normalizedSubject = message.subject.toLowerCase();
+
+    const matchedJob = jobs.find((job) =>
+        normalizedSubject.includes(job.company.toLowerCase()),
+    );
+
+    if (!matchedJob) {
+        return null;
+    }
+
+    return {
+        jobId: matchedJob.id,
+    };
+}


### PR DESCRIPTION
## Summary

Implements Gmail message matching and update extraction.

This PR adds:
- Gmail message → job matching
- Gmail message → update signal extraction
- composition into candidate updates

## What was built

### Matching
- `matchGmailMessageToJob`
- matches Gmail messages to jobs via company name heuristics

### Extraction
- `extractGmailUpdate`
- detects:
  - interview signals
  - rejection signals

### Composition
- `createGmailCandidateUpdate`
- combines:
  - matching
  - extraction
- outputs a structured candidate update:
  - jobId
  - messageId
  - status
  - note

## Notes

- heuristic-based (intentionally simple for now)
- no persistence yet
- no deduplication yet
- no timeline integration yet

## Validation

- all core tests pass
- typecheck passes