### PR TITLE
Stage 18: convert Gmail candidate updates into application events

### DIFF
--- a/packages/core/src/integrations/create-application-events-from-gmail-update.test.ts
+++ b/packages/core/src/integrations/create-application-events-from-gmail-update.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { createApplicationEventsFromGmailUpdate } from "./create-application-events-from-gmail-update";
+
+describe("createApplicationEventsFromGmailUpdate", () => {
+    it("creates status and note events for an interviewing update", () => {
+        const result = createApplicationEventsFromGmailUpdate({
+            jobId: "job-1",
+            messageId: "msg-1",
+            status: "interviewing",
+            note: "We would like to schedule an interview with the team.",
+        });
+
+        expect(result).toEqual([
+            {
+                jobId: "job-1",
+                type: "status_changed",
+                note: "gmail:msg-1 status -> interviewing",
+            },
+            {
+                jobId: "job-1",
+                type: "note_added",
+                note: "gmail:msg-1 We would like to schedule an interview with the team.",
+            },
+        ]);
+    });
+
+    it("creates status and note events for a rejection update", () => {
+        const result = createApplicationEventsFromGmailUpdate({
+            jobId: "job-1",
+            messageId: "msg-2",
+            status: "rejected",
+            note: "We have decided not to move forward at this time.",
+        });
+
+        expect(result).toEqual([
+            {
+                jobId: "job-1",
+                type: "status_changed",
+                note: "gmail:msg-2 status -> rejected",
+            },
+            {
+                jobId: "job-1",
+                type: "note_added",
+                note: "gmail:msg-2 We have decided not to move forward at this time.",
+            },
+        ]);
+    });
+});

--- a/packages/core/src/integrations/create-application-events-from-gmail-update.ts
+++ b/packages/core/src/integrations/create-application-events-from-gmail-update.ts
@@ -1,0 +1,28 @@
+export function createApplicationEventsFromGmailUpdate({
+    jobId,
+    messageId,
+    status,
+    note,
+}: {
+    jobId: string;
+    messageId: string;
+    status: "interviewing" | "rejected";
+    note: string;
+}): Array<{
+    jobId: string;
+    type: "status_changed" | "note_added";
+    note: string;
+}> {
+    return [
+        {
+            jobId,
+            type: "status_changed",
+            note: `gmail:${messageId} status -> ${status}`,
+        },
+        {
+            jobId,
+            type: "note_added",
+            note: `gmail:${messageId} ${note}`,
+        },
+    ];
+}


### PR DESCRIPTION
## Summary

Implements the mapping from Gmail candidate updates into application events.

This PR adds:
- Gmail candidate update → application events mapping

## What was built

### Mapping
- `createApplicationEventsFromGmailUpdate`
- converts a Gmail candidate update into existing application event shapes

### Output
For a supported Gmail update, the mapper creates:
- one `status_changed` event
- one `note_added` event

### Notes
- reuses existing event types
- does not introduce new event types
- persistence and review flow are still future work

## Validation

- all core tests pass
- typecheck passes