### PR TITLE
Issue #47: stage-23-add-navigation-and-app-layout

### DIFF
--- a/apps/job-coach-web/src/app/api/exports/route.ts
+++ b/apps/job-coach-web/src/app/api/exports/route.ts
@@ -1,7 +1,4 @@
 import { createExport } from "@coach/core";
-import { createExportsServer } from "../../../server/exports";
-
-const { exportDocument } = createExportsServer();
 
 function isNonEmptyString(value: unknown): value is string {
     return typeof value === "string" && value.trim().length > 0;
@@ -72,6 +69,9 @@ export async function POST(request: Request) {
     if (!isValidExportBody(body)) {
         return Response.json({ error: "INVALID_EXPORT_INPUT" }, { status: 400 });
     }
+
+    const { createExportsServer } = await import("../../../server/exports");
+    const { exportDocument } = createExportsServer();
 
     const result = await exportDocument(body);
 

--- a/apps/job-coach-web/src/app/api/workflows/[workflowRunId]/route.ts
+++ b/apps/job-coach-web/src/app/api/workflows/[workflowRunId]/route.ts
@@ -1,10 +1,12 @@
-import { workflowsServer } from "../../../../server/workflows-server";
-
 export async function GET(
     _request: Request,
     context: { params: Promise<{ workflowRunId: string }> },
 ) {
     const { workflowRunId } = await context.params;
+
+    const { workflowsServer } = await import(
+        "../../../../server/workflows-server"
+    );
 
     const result = await workflowsServer.getWorkflowRun({
         workflowRunId,

--- a/apps/job-coach-web/src/app/api/workflows/route.ts
+++ b/apps/job-coach-web/src/app/api/workflows/route.ts
@@ -1,5 +1,3 @@
-import { workflowsServer } from "../../../server/workflows-server";
-
 function isNonEmptyString(value: unknown): value is string {
     return typeof value === "string" && value.trim().length > 0;
 }
@@ -18,6 +16,7 @@ function isFormat(value: unknown): value is "pdf" | "docx" {
 }
 
 export async function GET() {
+    const { workflowsServer } = await import("../../../server/workflows-server");
     const runs = await workflowsServer.listWorkflowRuns();
 
     return Response.json(runs, { status: 200 });
@@ -29,6 +28,8 @@ export async function POST(request: Request) {
     if (!body || !isWorkflowType(body.workflowType)) {
         return Response.json({ error: "INVALID_WORKFLOW_INPUT" }, { status: 400 });
     }
+
+    const { workflowsServer } = await import("../../../server/workflows-server");
 
     try {
         if (body.workflowType === "import-job-and-score-fit") {

--- a/apps/job-coach-web/src/app/app-shell.tsx
+++ b/apps/job-coach-web/src/app/app-shell.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+export function AppShell({ children }: { children: ReactNode }) {
+    return (
+        <div style={{ display: "flex", minHeight: "100vh", flexDirection: "column" }}>
+            <header
+                style={{
+                    borderBottom: "1px solid #e5e5e5",
+                    padding: "12px 16px",
+                    display: "flex",
+                    gap: "16px",
+                }}
+            >
+                <strong>Job Coach</strong>
+
+                <nav style={{ display: "flex", gap: "12px" }}>
+                    <Link href="/">Home</Link>
+                    <Link href="/jobs">Jobs</Link>
+                    <Link href="/resumes">Resumes</Link>
+                    <Link href="/integrations">Integrations</Link>
+                </nav>
+            </header>
+
+            <main style={{ padding: "16px", flex: 1 }}>{children}</main>
+        </div>
+    );
+}

--- a/apps/job-coach-web/src/app/jobs/page.tsx
+++ b/apps/job-coach-web/src/app/jobs/page.tsx
@@ -1,0 +1,8 @@
+export default function JobsPage() {
+    return (
+        <div>
+            <h1>Jobs</h1>
+            <p>Jobs page coming soon.</p>
+        </div>
+    );
+}

--- a/apps/job-coach-web/src/app/layout.tsx
+++ b/apps/job-coach-web/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { AppShell } from "./app-shell";
 
 export default function RootLayout({
     children,
@@ -7,7 +8,9 @@ export default function RootLayout({
 }) {
     return (
         <html lang="en">
-            <body>{children}</body>
+            <body>
+                <AppShell>{children}</AppShell>
+            </body>
         </html>
     );
 }

--- a/apps/job-coach-web/src/app/resumes/page.tsx
+++ b/apps/job-coach-web/src/app/resumes/page.tsx
@@ -1,0 +1,8 @@
+export default function ResumesPage() {
+    return (
+        <div>
+            <h1>Resumes</h1>
+            <p>Resumes page coming soon.</p>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

Adds a basic application shell and navigation system to unify the Job Coach UI.

## What Changed

- Introduced `AppShell` component with header + navigation
- Wired global layout to wrap all pages
- Added navigation links:
  - Home (`/`)
  - Jobs (`/jobs`)
  - Resumes (`/resumes`)
  - Integrations (`/integrations`)
- Created placeholder pages for Jobs and Resumes
- Ensured all existing routes render within the shared layout

## Additional Fixes

- Resolved Next.js build failures by deferring server imports to request-time:
  - `/api/workflows/[workflowRunId]`
  - `/api/workflows`
  - `/api/exports`

## Result

- App now has a consistent UI shell
- Navigation works across all routes
- Build, typecheck, and tests all pass