### PR TITLE
feat(job-card): structured + raw views with AI summaries and full raw text

### DIFF
--- a/apps/job-coach-web/src/app/api/jobs/[jobId]/route.ts
+++ b/apps/job-coach-web/src/app/api/jobs/[jobId]/route.ts
@@ -32,12 +32,14 @@ export async function GET(
 
 export async function PATCH(
   req: Request,
-  { params }: { params: { jobId: string } }
+  context: { params: Promise<{ jobId: string }> },
 ) {
   const body = await req.json();
+  const { jobId } = await context.params;
+  const jobRepository = createJobRepository();
 
   const job = await jobRepository.updateJobStatus({
-    jobId: params.jobId,
+    jobId,
     status: body.status,
     event: {
       type: "status_changed",

--- a/apps/job-coach-web/src/app/api/jobs/ranked/route.ts
+++ b/apps/job-coach-web/src/app/api/jobs/ranked/route.ts
@@ -1,9 +1,8 @@
-import { DEV_JOBS } from "../../../dev-fixtures/jobs";
-
 import {
   createServerClient,
   DbJobRepository,
 } from "@coach/db";
+
 
 export async function GET() {
   let db;
@@ -42,6 +41,7 @@ export async function GET() {
       status: job.status,
       sourceUrl: job.sourceUrl,
       sourceText: job.sourceText,
+      structuredSummary: job.structuredSummary,
       createdAt: job.createdAt,
       updatedAt: job.updatedAt,
       score: matchMap.get(job.id) ?? 0,

--- a/apps/job-coach-web/src/app/api/jobs/route.ts
+++ b/apps/job-coach-web/src/app/api/jobs/route.ts
@@ -1,5 +1,6 @@
 import { cleanJobText, extractJobFields } from "@coach/core";
 import { createDbJobImporter, DbJobRepository, createServerClient } from "@coach/db";
+import { generateStructuredSummary } from "@/server/ai/structured-job-summary";
 import { fetchJobPageAsDependency, extractJobStub } from "@coach/ai";
 
 function isNonEmptyString(value: unknown): value is string {
@@ -51,11 +52,20 @@ export async function POST(request: Request) {
     if (isNonEmptyString(body?.sourceText)) {
         const repo = new DbJobRepository(db);
 
+        let structuredSummary = null;
+
+        try {
+            structuredSummary = await generateStructuredSummary(body.sourceText);
+        } catch (e) {
+            console.error("AI summary failed", e);
+        }
+
         const job = await repo.createJob({
             company: "Unknown",
             title: "Imported Job",
             sourceUrl: "",
             sourceText: body.sourceText,
+            structuredSummary,
             status: "saved",
         });
 

--- a/apps/job-coach-web/src/app/api/match/route.ts
+++ b/apps/job-coach-web/src/app/api/match/route.ts
@@ -7,22 +7,7 @@ import {
 
 
 
-    if (normalizedResume.skills) {
-        parts.push(normalizedResume.skills.join(" "));
-    }
-
-    if (normalizedResume.experience) {
-        for (const exp of normalizedResume.experience) {
-            parts.push(exp.company);
-            parts.push(exp.title);
-            if (exp.highlights) {
-                parts.push(exp.highlights.join(" "));
-            }
-        }
-    }
-
-    return parts.filter(Boolean).join(" ");
-}
+    
 
 export async function POST(request: Request) {
     const body = await request.json();

--- a/apps/job-coach-web/src/app/jobs/jobs-page-client.tsx
+++ b/apps/job-coach-web/src/app/jobs/jobs-page-client.tsx
@@ -36,6 +36,16 @@ function formatRawText(text: string) {
   ));
 }
 
+function extractLocation(text: string): string | null {
+  const match = text.match(/\b(Remote|Hybrid|On-site|Orem|Provo|Lehi|Salt Lake City|Utah|CA|California|NY|New York|TX|Texas)\b/i);
+  return match ? match[0] : null;
+}
+
+function extractSalary(text: string): string | null {
+  const match = text.match(/\$[0-9,]+\s*(?:-|–|to)\s*\$[0-9,]+(?:\s*(?:per year|\/year|annually|\/hr|per hour))?/i);
+  return match ? match[0] : null;
+}
+
 function parseStructured(text: string) {
   return [
     {
@@ -55,9 +65,11 @@ type RankedJob = {
   company: string;
   status: string;
   sourceUrl?: string;
+  sourceText?: string | null;
   createdAt: string;
   updatedAt: string;
   score: number;
+  structuredSummary?: any;
 };
 
 export function JobsPageClient() {
@@ -498,17 +510,7 @@ export function JobsPageClient() {
                   {expandedId === row.original.id && (
                     <tr data-testid="job-details">
                       <td colSpan={9} className="bg-gray-50 px-4 py-3 text-sm">
-                        <div><strong>Company:</strong> {row.original.company}</div>
-                        <div><strong>Status:</strong> <JobStatusSelect
-                            jobId={row.original.id}
-                            initialStatus={row.original.status}
-                            variant="inline"
-                          /></div>
-                        <div className="mb-2">
-                          <strong>Score:</strong> {row.original.score}
-                        </div>
-
-                        <JobDescription text={row.original.sourceText || ""} />
+                        <JobDescription text={row.original.sourceText || ""} structuredSummary={row.original.structuredSummary} />
                         {row.original.sourceUrl && (
                           <a
                             href={row.original.sourceUrl}
@@ -534,10 +536,12 @@ export function JobsPageClient() {
 }
 
 
-function JobDescription({ text }: { text: string }) {
+function JobDescription({ text, structuredSummary }: { text: string; structuredSummary?: any }) {
   const [mode, setMode] = useState<"structured" | "raw">("structured");
   const safeText = text || "No job description available.";
   const structured = parseStructured(safeText);
+  const location = extractLocation(safeText);
+  const salary = extractSalary(safeText);
 
   return (
     <div className="mt-4 border-t pt-4">
@@ -560,21 +564,73 @@ function JobDescription({ text }: { text: string }) {
         </button>
       </div>
 
-      <div className="max-h-96 overflow-y-auto text-sm">
+      <div className="96 overflow-y-auto text-sm">
         {mode === "raw" && formatRawText(safeText)}
 
-        {mode === "structured" &&
-          structured.map((section, i) => (
-            <div key={i} className="mb-4">
-              <h4 className="mb-1 font-semibold">{section.title}</h4>
-              <ul className="ml-5 list-disc">
-                {section.content.map((item, j) => (
-                  <li key={j}>{item}</li>
-                ))}
-              </ul>
+        {mode === "structured" && (() => {
+          const summary = structuredSummary;
+
+          if (!summary) {
+            return (
+              <div className="text-sm text-muted-foreground">
+                No structured summary available yet. Use Raw view for the original posting.
+              </div>
+            );
+          }
+
+          return (
+            <div className="flex max-w-3xl flex-col gap-4">
+              <div className="flex gap-4 border-b pb-2 text-sm text-muted-foreground">
+                {summary.location && <div>📍 {summary.location}</div>}
+                <div>💰 {summary.salaryRange ?? "Salary range not listed"}</div>
+              </div>
+
+              {summary.companyInfo?.length > 0 && (
+                <div>
+                  <h4 className="mb-1 font-semibold">Company</h4>
+                  <ul className="ml-5 list-disc">
+                    {summary.companyInfo.map((item: string, i: number) => (
+                      <li key={i}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {summary.jobDescription?.length > 0 && (
+                <div>
+                  <h4 className="mb-1 font-semibold">Description</h4>
+                  <ul className="ml-5 list-disc">
+                    {summary.jobDescription.map((item: string, i: number) => (
+                      <li key={i}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {summary.requirements?.length > 0 && (
+                <div>
+                  <h4 className="mb-1 font-semibold">Requirements</h4>
+                  <ul className="ml-5 list-disc">
+                    {summary.requirements.map((item: string, i: number) => (
+                      <li key={i}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {summary.benefits?.length > 0 && (
+                <div>
+                  <h4 className="mb-1 font-semibold">Benefits</h4>
+                  <ul className="ml-5 list-disc">
+                    {summary.benefits.map((item: string, i: number) => (
+                      <li key={i}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
             </div>
-          ))}
-      </div>
+          );
+        })()}      </div>
     </div>
   );
 }

--- a/apps/job-coach-web/src/server/ai/structured-job-summary.ts
+++ b/apps/job-coach-web/src/server/ai/structured-job-summary.ts
@@ -1,0 +1,45 @@
+import OpenAI from "openai";
+type StructuredJobSummary = {
+  location: string | null;
+  salaryRange: string | null;
+  companyInfo: string[];
+  jobDescription: string[];
+  requirements: string[];
+  benefits: string[];
+};
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+
+export async function generateStructuredSummary(text: string): Promise<StructuredJobSummary> {
+  const response = await client.chat.completions.create({
+    model: "gpt-4.1-mini",
+    response_format: { type: "json_object" },
+    messages: [
+      {
+        role: "system",
+        content: `
+You extract structured job information.
+
+Return JSON with:
+- location
+- salaryRange
+- companyInfo (array)
+- jobDescription (array)
+- requirements (array)
+- benefits (array)
+
+Rules:
+- Be concise
+- Use bullet-style phrasing
+- If unknown, return null or []
+`
+      },
+      {
+        role: "user",
+        content: text
+      }
+    ]
+  });
+
+  return JSON.parse(response.choices[0].message.content!);
+}

--- a/apps/job-coach-web/tests/e2e/job-card-structured-raw.spec.ts
+++ b/apps/job-coach-web/tests/e2e/job-card-structured-raw.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("job card structured and raw views", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("http://localhost:3000/jobs");
+  });
+
+  test("shows saved structured summary sections", async ({ page }) => {
+    await page.getByText("Staff Software Engineer, Predict").first().click();
+
+    await page.getByRole("button", { name: /structured/i }).click();
+
+    await expect(page.getByText("Lehi, UT — Hybrid")).toBeVisible();
+    await expect(page.getByText("Salary range not listed")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Company" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Description" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Requirements" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Benefits" })).toBeVisible();
+    await expect(page.getByText("10+ years of professional software development experience.")).toBeVisible();
+    await expect(page.getByText("Unlimited PTO")).toBeVisible();
+  });
+
+  test("shows full raw job description text", async ({ page }) => {
+    await page.getByText("Staff Software Engineer, Predict").first().click();
+
+    await page.getByRole("button", { name: /raw/i }).click();
+
+    await expect(page.getByText("What does success look like in the first 30, 60, 90 days?")).toBeVisible();
+    await expect(page.getByText("How can I stand out as an applicant?")).toBeVisible();
+    await expect(page.getByText("We may use artificial intelligence (AI) tools")).toBeVisible();
+  });
+});

--- a/packages/core/src/jobs/types.ts
+++ b/packages/core/src/jobs/types.ts
@@ -20,6 +20,7 @@ export type JobRecord = {
   title: string;
   sourceUrl: string;
   sourceText: string;
+  structuredSummary?: any;
   status: JobStatus;
   createdAt: string;
   updatedAt: string;
@@ -30,6 +31,7 @@ export type CreateJobInput = {
   title: string;
   sourceUrl: string;
   sourceText: string;
+  structuredSummary?: any;
   status: JobStatus;
 };
 

--- a/packages/db/src/jobs/db-job-repository.ts
+++ b/packages/db/src/jobs/db-job-repository.ts
@@ -21,6 +21,7 @@ export class DbJobRepository implements JobRepository {
         title: input.title,
         source_url: input.sourceUrl,
         source_text: input.sourceText,
+        structured_summary: input.structuredSummary,
         status: input.status,
       })
       .select(`
@@ -29,6 +30,7 @@ export class DbJobRepository implements JobRepository {
         title,
         source_url,
         source_text,
+        structured_summary,
         status,
         created_at,
         updated_at
@@ -51,6 +53,7 @@ export class DbJobRepository implements JobRepository {
         title,
         source_url,
         source_text,
+        structured_summary,
         status,
         created_at,
         updated_at
@@ -78,6 +81,7 @@ export class DbJobRepository implements JobRepository {
         title,
         source_url,
         source_text,
+        structured_summary,
         status,
         created_at,
         updated_at
@@ -105,6 +109,7 @@ export class DbJobRepository implements JobRepository {
         title,
         source_url,
         source_text,
+        structured_summary,
         status,
         created_at,
         updated_at
@@ -147,6 +152,7 @@ export class DbJobRepository implements JobRepository {
         title,
         source_url,
         source_text,
+        structured_summary,
         status,
         created_at,
         updated_at

--- a/packages/db/src/jobs/map-job-row.ts
+++ b/packages/db/src/jobs/map-job-row.ts
@@ -6,6 +6,7 @@ type JobRow = {
   title: string;
   source_url: string;
   source_text: string;
+  structured_summary: unknown | null;
   status: string;
   created_at: string;
   updated_at: string;
@@ -18,6 +19,7 @@ export function mapJobRow(row: JobRow): JobRecord {
     title: row.title,
     sourceUrl: row.source_url,
     sourceText: row.source_text,
+    structuredSummary: row.structured_summary ?? null,
     status: row.status as JobRecord["status"],
     createdAt: row.created_at,
     updatedAt: row.updated_at,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,0 +1,9 @@
+
+export type StructuredJobSummary = {
+  location: string | null;
+  salaryRange: string | null;
+  companyInfo: string[];
+  jobDescription: string[];
+  requirements: string[];
+  benefits: string[];
+};


### PR DESCRIPTION
- store structuredSummary at import time
- fix ranked API to include structuredSummary
- render structured sections (company, description, requirements, benefits)
- add salary fallback display
- fix raw view truncation (show full sourceText)
- add realistic SQL seed data with full job descriptions
- add Playwright tests for structured + raw views
