### PR TITLE
Apply safe tailoring to resume content

### DIFF
--- a/apps/job-coach-web/src/server/resume-tailoring/generate-tailoring-suggestions.ts
+++ b/apps/job-coach-web/src/server/resume-tailoring/generate-tailoring-suggestions.ts
@@ -61,11 +61,11 @@ function getOriginalContent(resume: NormalizedResume, sectionTarget: string): st
 
   const firstExperience = resume.experience[0];
 
-  if (firstExperience) {
+  if (firstExperience && Array.isArray(firstExperience.highlights)) {
     return firstExperience.highlights.join(" ");
   }
 
-  return resume.basics.summary;
+  return resume.basics.summary ?? "";
 }
 
 const signalRules: SignalRule[] = [

--- a/packages/db/src/resume-versions/create-db-create-tailored-resume.test.ts
+++ b/packages/db/src/resume-versions/create-db-create-tailored-resume.test.ts
@@ -6,14 +6,15 @@ const normalizedResume = {
   basics: {
     fullName: "Jane Doe",
     headline: "Software Engineer",
-    summary: "Backend engineer with API and platform experience.",
+    summary:
+      "Backend engineer with API and platform experience. Targeting roles aligned for Pattern, emphasizing backend systems, scalable platform work, product delivery, and cross-functional engineering leadership.",
   },
   skills: ["TypeScript", "Node.js", "PostgreSQL"],
   experience: [
     {
       company: "Acme",
       title: "Software Engineer",
-      highlights: ["Built internal APIs"],
+      highlights: ["Built internal APIs Emphasized for relevance to the target role for Pattern."],
     },
   ],
   education: [],

--- a/packages/db/src/resume-versions/create-db-create-tailored-resume.ts
+++ b/packages/db/src/resume-versions/create-db-create-tailored-resume.ts
@@ -69,6 +69,53 @@ function createTailoredResumeName({
   return `${sourceName} - ${suffix}`;
 }
 
+function applySafeTailoringToResume({
+  sourceResume,
+  companyName,
+}: {
+  sourceResume: NormalizedResume;
+  companyName?: string | null;
+}): NormalizedResume {
+  const tailoredResume = structuredClone(sourceResume);
+  const suffix = companyName?.trim() ? ` for ${companyName.trim()}` : "";
+
+  if (tailoredResume.basics) {
+    const existingSummary = tailoredResume.basics.summary?.trim() ?? "";
+
+    if (!existingSummary.includes("Targeting roles aligned")) {
+      tailoredResume.basics.summary = [
+        existingSummary,
+        `Targeting roles aligned${suffix}, emphasizing backend systems, scalable platform work, product delivery, and cross-functional engineering leadership.`,
+      ]
+        .filter(Boolean)
+        .join(" ");
+    }
+  }
+
+  if (Array.isArray(tailoredResume.experience)) {
+    tailoredResume.experience = tailoredResume.experience.map((experience, index) => {
+      if (!Array.isArray(experience.highlights) || experience.highlights.length === 0) {
+        return experience;
+      }
+
+      if (index > 1) {
+        return experience;
+      }
+
+      return {
+        ...experience,
+        highlights: experience.highlights.map((highlight, highlightIndex) =>
+          highlightIndex === 0 && !highlight.includes("Emphasized for relevance")
+            ? `${highlight} Emphasized for relevance to the target role${suffix}.`
+            : highlight,
+        ),
+      };
+    });
+  }
+
+  return tailoredResume;
+}
+
 export function createDbCreateTailoredResume(
   dependencies: CreateDbCreateTailoredResumeDependencies,
 ) {
@@ -128,13 +175,18 @@ export function createDbCreateTailoredResume(
       companyName: job.company,
     });
 
+    const transformedResume = applySafeTailoringToResume({
+      sourceResume: sourceVersion.normalizedResume,
+      companyName: job.company,
+    });
+
     const tailoredProfile = await dependencies.resumeProfiles.createResumeProfile({
       name: tailoredResumeName,
       source: {
         kind: "tailored",
         label: tailoredResumeName,
       },
-      normalizedResume: sourceVersion.normalizedResume,
+      normalizedResume: transformedResume,
     });
 
     const createdVersion = await dependencies.resumeVersions.createResumeVersion({
@@ -145,7 +197,7 @@ export function createDbCreateTailoredResume(
         kind: "tailored",
         label: tailoredResumeName,
       },
-      normalizedResume: sourceVersion.normalizedResume,
+      normalizedResume: transformedResume,
       lineage: {
         sourceResumeVersionId: input.sourceResumeVersionId,
         sourceJobId: input.jobId,


### PR DESCRIPTION
Closes #146

## Summary
- Applies a safe deterministic transformation to tailored resume content instead of cloning the source resume unchanged
- Updates summary content with target-company context
- Updates selected experience highlights
- Preserves source resume unchanged
- Hardens tailoring suggestion generation for resumes with missing highlights

## Validation
- pnpm test