### PR TITLE
Issue #160: Improve match analysis quality and decision-support UX

### DIFF
--- a/apps/job-coach-web/src/app/api/jobs/ranked/route.test.ts
+++ b/apps/job-coach-web/src/app/api/jobs/ranked/route.test.ts
@@ -65,10 +65,12 @@ describe("createRankedMatchDetails", () => {
         sourceText: "TypeScript React product workflows",
       }),
     ).toEqual({
-      strengths: ["Saved fit score suggests relevant overlap with Product Engineer requirements."],
+      strengths: [
+        "Product Engineer shows 82% fit with posting signals such as Typescript, React, Product, Workflows.",
+      ],
       gaps: [],
       reasons: [
-        "Fit analysis is based on the saved match score and Product Engineer posting data.",
+        "Legacy Product Engineer match: 82% fit with posting signals such as Typescript, React, Product, Workflows.",
       ],
       recommendation:
         "Strong fit for Product Engineer. Prioritize this role and tailor the resume around Typescript, React, Product, Workflows.",
@@ -76,10 +78,10 @@ describe("createRankedMatchDetails", () => {
     expect(createRankedMatchDetails(17, { title: "Support Engineer" })).toEqual({
       strengths: [],
       gaps: [
-        "Review resume evidence for the saved job requirements; the saved fit score indicates possible gaps.",
+        "Before applying to Support Engineer, verify resume evidence for the core role requirements; this legacy match is below the strong-fit range.",
       ],
       reasons: [
-        "Fit analysis is based on the saved match score and Support Engineer posting data.",
+        "Legacy Support Engineer match: 17% fit with posting signals such as the core role requirements.",
       ],
       recommendation:
         "Weak fit for Support Engineer. Apply only if there is strong interest or missing resume context.",
@@ -187,7 +189,10 @@ describe("GET /api/jobs/ranked", () => {
     const response = await GET();
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual([
+    const body = await response.json();
+
+    expect(selectJobMatches).toHaveBeenCalledWith("job_id, score, match_details");
+    expect(body).toEqual([
       expect.objectContaining({
         id: "job-new",
         score: null,
@@ -211,7 +216,7 @@ describe("GET /api/jobs/ranked", () => {
         matchDetails: expect.objectContaining({
           strengths: [],
           gaps: [
-            "Review resume evidence for Build, Interfaces; the saved fit score indicates possible gaps.",
+            "Before applying to Frontend Engineer, verify resume evidence for Interfaces; this legacy match is below the strong-fit range.",
           ],
         }),
       }),
@@ -221,7 +226,7 @@ describe("GET /api/jobs/ranked", () => {
         matchDetails: expect.objectContaining({
           strengths: [],
           gaps: [
-            "Review resume evidence for Support, Customers; the saved fit score indicates possible gaps.",
+            "Before applying to Support Engineer, verify resume evidence for Support, Customers; this legacy match is below the strong-fit range.",
           ],
         }),
       }),
@@ -231,5 +236,8 @@ describe("GET /api/jobs/ranked", () => {
         matchDetails: null,
       }),
     ]);
+    expect(JSON.stringify(body)).not.toContain("Good keyword overlap");
+    expect(JSON.stringify(body)).not.toContain("Saved fit score suggests relevant overlap");
+    expect(JSON.stringify(body)).not.toContain("Fit analysis is based on the saved match score");
   });
 });

--- a/apps/job-coach-web/src/app/api/jobs/ranked/route.test.ts
+++ b/apps/job-coach-web/src/app/api/jobs/ranked/route.test.ts
@@ -58,16 +58,31 @@ describe("normalizeRankedScore", () => {
 });
 
 describe("createRankedMatchDetails", () => {
-  it("mirrors current matcher reasoning for persisted match scores", () => {
-    expect(createRankedMatchDetails(82)).toEqual({
-      strengths: ["Good keyword overlap"],
+  it("creates role-specific fallback details for legacy match rows", () => {
+    expect(
+      createRankedMatchDetails(82, {
+        title: "Product Engineer",
+        sourceText: "TypeScript React product workflows",
+      }),
+    ).toEqual({
+      strengths: ["Saved fit score suggests relevant overlap with Product Engineer requirements."],
       gaps: [],
-      reasons: ["Good keyword overlap"],
+      reasons: [
+        "Fit analysis is based on the saved match score and Product Engineer posting data.",
+      ],
+      recommendation:
+        "Strong fit for Product Engineer. Prioritize this role and tailor the resume around Typescript, React, Product, Workflows.",
     });
-    expect(createRankedMatchDetails(17)).toEqual({
+    expect(createRankedMatchDetails(17, { title: "Support Engineer" })).toEqual({
       strengths: [],
-      gaps: ["Low keyword overlap"],
-      reasons: ["Low keyword overlap"],
+      gaps: [
+        "Review resume evidence for the saved job requirements; the saved fit score indicates possible gaps.",
+      ],
+      reasons: [
+        "Fit analysis is based on the saved match score and Support Engineer posting data.",
+      ],
+      recommendation:
+        "Weak fit for Support Engineer. Apply only if there is strong interest or missing resume context.",
     });
   });
 });
@@ -148,6 +163,13 @@ describe("GET /api/jobs/ranked", () => {
         {
           job_id: "job-high",
           score: 82,
+          match_details: {
+            strengths: ["Resume evidence overlaps with Product Engineer: TypeScript, React."],
+            gaps: ["Seniority alignment is unclear for a staff-level role."],
+            reasons: ["Resume evidence overlaps with Product Engineer: TypeScript, React."],
+            recommendation:
+              "Strong fit for Product Engineer. Prioritize this role and tailor the resume around TypeScript and React.",
+          },
         },
         {
           job_id: "job-low",
@@ -175,29 +197,33 @@ describe("GET /api/jobs/ranked", () => {
         id: "job-high",
         score: 0.82,
         matchDetails: {
-          strengths: ["Good keyword overlap"],
-          gaps: [],
-          reasons: ["Good keyword overlap"],
+          strengths: ["Resume evidence overlaps with Product Engineer: TypeScript, React."],
+          gaps: ["Seniority alignment is unclear for a staff-level role."],
+          reasons: ["Resume evidence overlaps with Product Engineer: TypeScript, React."],
+          recommendation:
+            "Strong fit for Product Engineer. Prioritize this role and tailor the resume around TypeScript and React.",
         },
         structuredSummary,
       }),
       expect.objectContaining({
         id: "job-low",
         score: 0.17,
-        matchDetails: {
+        matchDetails: expect.objectContaining({
           strengths: [],
-          gaps: ["Low keyword overlap"],
-          reasons: ["Low keyword overlap"],
-        },
+          gaps: [
+            "Review resume evidence for Build, Interfaces; the saved fit score indicates possible gaps.",
+          ],
+        }),
       }),
       expect.objectContaining({
         id: "job-zero",
         score: 0,
-        matchDetails: {
+        matchDetails: expect.objectContaining({
           strengths: [],
-          gaps: ["Low keyword overlap"],
-          reasons: ["Low keyword overlap"],
-        },
+          gaps: [
+            "Review resume evidence for Support, Customers; the saved fit score indicates possible gaps.",
+          ],
+        }),
       }),
       expect.objectContaining({
         id: "job-unmatched",

--- a/apps/job-coach-web/src/app/api/jobs/ranked/route.test.ts
+++ b/apps/job-coach-web/src/app/api/jobs/ranked/route.test.ts
@@ -66,25 +66,36 @@ describe("createRankedMatchDetails", () => {
       }),
     ).toEqual({
       strengths: [
-        "Product Engineer shows 82% fit with posting signals such as Typescript, React, Product, Workflows.",
+        "Resume shows some relevant evidence for Product Engineer.",
       ],
       gaps: [],
-      reasons: [
-        "Legacy Product Engineer match: 82% fit with posting signals such as Typescript, React, Product, Workflows.",
-      ],
+      reasons: ["Legacy Product Engineer match: 82% fit using saved score data."],
       recommendation:
-        "Strong fit for Product Engineer. Prioritize this role and tailor the resume around Typescript, React, Product, Workflows.",
+        "Strong overlap detected. Prioritize Product Engineer and tailor the resume toward TypeScript, React and Workflows.",
     });
     expect(createRankedMatchDetails(17, { title: "Support Engineer" })).toEqual({
       strengths: [],
       gaps: [
-        "Before applying to Support Engineer, verify resume evidence for the core role requirements; this legacy match is below the strong-fit range.",
+        "The application would be stronger with clearer evidence of the core role requirements.",
       ],
-      reasons: [
-        "Legacy Support Engineer match: 17% fit with posting signals such as the core role requirements.",
-      ],
+      reasons: ["Legacy Support Engineer match: 17% fit using saved score data."],
       recommendation:
-        "Weak fit for Support Engineer. Apply only if there is strong interest or missing resume context.",
+        "Weak overlap detected. Build clearer resume evidence around the core role requirements before prioritizing this role.",
+    });
+    expect(
+      createRankedMatchDetails(36, {
+        title: "Analytics Engineer",
+        sourceText:
+          "predictive analytics job obsessed partner team platform data product engineering",
+      }),
+    ).toEqual({
+      strengths: ["Resume shows some relevant evidence for Analytics Engineer."],
+      gaps: [
+        "The application would be stronger with clearer evidence of Predictive, platform, data and Product.",
+      ],
+      reasons: ["Legacy Analytics Engineer match: 36% fit using saved score data."],
+      recommendation:
+        "Moderate overlap detected. Tailoring the resume toward Predictive, platform, data and Product would strengthen the application.",
     });
   });
 });
@@ -216,7 +227,7 @@ describe("GET /api/jobs/ranked", () => {
         matchDetails: expect.objectContaining({
           strengths: [],
           gaps: [
-            "Before applying to Frontend Engineer, verify resume evidence for Interfaces; this legacy match is below the strong-fit range.",
+            "The application would be stronger with clearer evidence of Interfaces.",
           ],
         }),
       }),
@@ -226,7 +237,7 @@ describe("GET /api/jobs/ranked", () => {
         matchDetails: expect.objectContaining({
           strengths: [],
           gaps: [
-            "Before applying to Support Engineer, verify resume evidence for Support, Customers; this legacy match is below the strong-fit range.",
+            "The application would be stronger with clearer evidence of Customers.",
           ],
         }),
       }),
@@ -239,5 +250,6 @@ describe("GET /api/jobs/ranked", () => {
     expect(JSON.stringify(body)).not.toContain("Good keyword overlap");
     expect(JSON.stringify(body)).not.toContain("Saved fit score suggests relevant overlap");
     expect(JSON.stringify(body)).not.toContain("Fit analysis is based on the saved match score");
+    expect(JSON.stringify(body)).not.toContain("posting signals such as");
   });
 });

--- a/apps/job-coach-web/src/app/api/jobs/ranked/route.ts
+++ b/apps/job-coach-web/src/app/api/jobs/ranked/route.ts
@@ -66,14 +66,21 @@ function formatFallbackTerm(value: string) {
 function getFallbackTerms(job: RankedJobSource) {
   const summary = job.structuredSummary as Record<string, unknown> | null | undefined;
   const requirements = Array.isArray(summary?.requirements)
-    ? summary.requirements.filter((item): item is string => typeof item === "string")
+    ? summary.requirements
+        .filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+        .map((item) => item.trim())
     : [];
   const sourceTerms = (job.sourceText ?? "")
     .toLowerCase()
     .split(/[^a-z0-9+#.]+/i)
-    .filter((term) => term.length > 2 && !["and", "for", "the", "with", "you"].includes(term));
+    .filter(
+      (term) =>
+        term.length > 2 &&
+        !["and", "build", "for", "the", "with", "you", "your"].includes(term) &&
+        !/^\d+$/.test(term),
+    );
 
-  return Array.from(new Set([...requirements.flatMap((item) => item.split(/\W+/)), ...sourceTerms]))
+  return Array.from(new Set([...requirements, ...sourceTerms]))
     .filter(Boolean)
     .slice(0, 5)
     .map(formatFallbackTerm);
@@ -82,7 +89,8 @@ function getFallbackTerms(job: RankedJobSource) {
 export function createRankedMatchDetails(score: number, job: RankedJobSource): RankedMatchDetails {
   const title = job.title?.trim() || "this role";
   const terms = getFallbackTerms(job);
-  const termText = terms.length > 0 ? terms.join(", ") : "the saved job requirements";
+  const termText = terms.length > 0 ? terms.join(", ") : "the core role requirements";
+  const legacyReason = `Legacy ${title} match: ${score}% fit with posting signals such as ${termText}.`;
   const recommendation =
     score >= 80
       ? `Strong fit for ${title}. Prioritize this role and tailor the resume around ${termText}.`
@@ -94,12 +102,14 @@ export function createRankedMatchDetails(score: number, job: RankedJobSource): R
 
   return {
     strengths:
-      score >= 40 ? [`Saved fit score suggests relevant overlap with ${title} requirements.`] : [],
+      score >= 40 ? [`${title} shows ${score}% fit with posting signals such as ${termText}.`] : [],
     gaps:
       score < 60
-        ? [`Review resume evidence for ${termText}; the saved fit score indicates possible gaps.`]
+        ? [
+            `Before applying to ${title}, verify resume evidence for ${termText}; this legacy match is below the strong-fit range.`,
+          ]
         : [],
-    reasons: [`Fit analysis is based on the saved match score and ${title} posting data.`],
+    reasons: [legacyReason],
     recommendation,
   };
 }

--- a/apps/job-coach-web/src/app/api/jobs/ranked/route.ts
+++ b/apps/job-coach-web/src/app/api/jobs/ranked/route.ts
@@ -5,12 +5,14 @@ import { compareRankedJobSignals } from "@/lib/jobs-table-signals";
 type JobMatchRow = {
   job_id: string;
   score: unknown;
+  match_details?: unknown;
 };
 
 type RankedMatchDetails = {
   strengths: string[];
   gaps: string[];
   reasons: string[];
+  recommendation?: string;
 };
 
 export function normalizeRankedScore(score: unknown) {
@@ -21,13 +23,84 @@ export function normalizeRankedScore(score: unknown) {
   return Math.max(0, Math.min(score / 100, 1));
 }
 
-export function createRankedMatchDetails(score: number): RankedMatchDetails {
-  const reason = score > 30 ? "Good keyword overlap" : "Low keyword overlap";
+function getStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+    : [];
+}
+
+function normalizeMatchDetails(value: unknown): RankedMatchDetails | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const details = value as Record<string, unknown>;
+  const strengths = getStringArray(details.strengths);
+  const gaps = getStringArray(details.gaps);
+  const reasons = getStringArray(details.reasons);
+  const recommendation =
+    typeof details.recommendation === "string" && details.recommendation.trim().length > 0
+      ? details.recommendation
+      : undefined;
+
+  if (strengths.length === 0 && gaps.length === 0 && reasons.length === 0 && !recommendation) {
+    return null;
+  }
+
+  return { strengths, gaps, reasons, recommendation };
+}
+
+type RankedJobSource = {
+  title?: string;
+  company?: string;
+  sourceText?: string | null;
+  structuredSummary?: unknown;
+};
+
+function formatFallbackTerm(value: string) {
+  return value
+    .replace(/^[^a-z0-9+#]+|[^a-z0-9+#]+$/gi, "")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function getFallbackTerms(job: RankedJobSource) {
+  const summary = job.structuredSummary as Record<string, unknown> | null | undefined;
+  const requirements = Array.isArray(summary?.requirements)
+    ? summary.requirements.filter((item): item is string => typeof item === "string")
+    : [];
+  const sourceTerms = (job.sourceText ?? "")
+    .toLowerCase()
+    .split(/[^a-z0-9+#.]+/i)
+    .filter((term) => term.length > 2 && !["and", "for", "the", "with", "you"].includes(term));
+
+  return Array.from(new Set([...requirements.flatMap((item) => item.split(/\W+/)), ...sourceTerms]))
+    .filter(Boolean)
+    .slice(0, 5)
+    .map(formatFallbackTerm);
+}
+
+export function createRankedMatchDetails(score: number, job: RankedJobSource): RankedMatchDetails {
+  const title = job.title?.trim() || "this role";
+  const terms = getFallbackTerms(job);
+  const termText = terms.length > 0 ? terms.join(", ") : "the saved job requirements";
+  const recommendation =
+    score >= 80
+      ? `Strong fit for ${title}. Prioritize this role and tailor the resume around ${termText}.`
+      : score >= 60
+        ? `Good fit for ${title}. Worth applying with a tailored resume that reinforces ${termText}.`
+        : score >= 40
+          ? `Moderate fit for ${title}. Consider applying if the role is interesting, but tailor carefully around ${termText}.`
+          : `Weak fit for ${title}. Apply only if there is strong interest or missing resume context.`;
 
   return {
-    strengths: score > 30 ? [reason] : [],
-    gaps: score > 30 ? [] : [reason],
-    reasons: [reason],
+    strengths:
+      score >= 40 ? [`Saved fit score suggests relevant overlap with ${title} requirements.`] : [],
+    gaps:
+      score < 60
+        ? [`Review resume evidence for ${termText}; the saved fit score indicates possible gaps.`]
+        : [],
+    reasons: [`Fit analysis is based on the saved match score and ${title} posting data.`],
+    recommendation,
   };
 }
 
@@ -52,9 +125,9 @@ export async function GET() {
 
   const jobs = await jobRepo.listJobs();
 
-  const { data: matches } = await db.from("job_matches").select("job_id, score");
+  const { data: matches } = await db.from("job_matches").select("job_id, score, match_details");
 
-  const matchMap = new Map<string, { score: number; matchDetails: RankedMatchDetails }>();
+  const matchMap = new Map<string, { score: number; matchDetails: RankedMatchDetails | null }>();
 
   for (const match of (matches || []) as JobMatchRow[]) {
     const normalizedScore = normalizeRankedScore(match.score);
@@ -62,7 +135,7 @@ export async function GET() {
     if (normalizedScore !== null) {
       matchMap.set(match.job_id, {
         score: normalizedScore,
-        matchDetails: createRankedMatchDetails(match.score as number),
+        matchDetails: normalizeMatchDetails(match.match_details),
       });
     }
   }
@@ -79,7 +152,11 @@ export async function GET() {
       createdAt: job.createdAt,
       updatedAt: job.updatedAt,
       score: matchMap.get(job.id)?.score ?? null,
-      matchDetails: matchMap.get(job.id)?.matchDetails ?? null,
+      matchDetails:
+        matchMap.get(job.id)?.matchDetails ??
+        (matchMap.has(job.id)
+          ? createRankedMatchDetails(matchMap.get(job.id)!.score * 100, job)
+          : null),
     }))
     .sort(compareRankedJobSignals);
 

--- a/apps/job-coach-web/src/app/api/jobs/ranked/route.ts
+++ b/apps/job-coach-web/src/app/api/jobs/ranked/route.ts
@@ -58,12 +58,67 @@ type RankedJobSource = {
 };
 
 function formatFallbackTerm(value: string) {
-  return value
-    .replace(/^[^a-z0-9+#]+|[^a-z0-9+#]+$/gi, "")
-    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+  const cleaned = value.replace(/^[^a-z0-9+#]+|[^a-z0-9+#]+$/gi, "").toLowerCase();
+  const labels: Record<string, string> = {
+    ai: "AI",
+    apis: "APIs",
+    data: "data",
+    fintech: "fintech",
+    healthcare: "healthcare",
+    ml: "ML",
+    platform: "platform",
+    react: "React",
+    typescript: "TypeScript",
+  };
+
+  return labels[cleaned] ?? cleaned.replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function formatFallbackTerms(terms: string[], fallback: string) {
+  if (terms.length === 0) {
+    return fallback;
+  }
+
+  if (terms.length === 1) {
+    return terms[0];
+  }
+
+  return `${terms.slice(0, -1).join(", ")} and ${terms[terms.length - 1]}`;
 }
 
 function getFallbackTerms(job: RankedJobSource) {
+  const blockedTerms = new Set([
+    ...String(job.title ?? "")
+      .toLowerCase()
+      .split(/[^a-z0-9+#.]+/i)
+      .filter(Boolean),
+    ...String(job.company ?? "")
+      .toLowerCase()
+      .split(/[^a-z0-9+#.]+/i)
+      .filter(Boolean),
+    "and",
+    "build",
+    "company",
+    "culture",
+    "dynamic",
+    "engineer",
+    "engineering",
+    "fast",
+    "for",
+    "job",
+    "mission",
+    "obsessed",
+    "opportunity",
+    "partner",
+    "passionate",
+    "team",
+    "the",
+    "use",
+    "with",
+    "world",
+    "you",
+    "your",
+  ]);
   const summary = job.structuredSummary as Record<string, unknown> | null | undefined;
   const requirements = Array.isArray(summary?.requirements)
     ? summary.requirements
@@ -76,11 +131,12 @@ function getFallbackTerms(job: RankedJobSource) {
     .filter(
       (term) =>
         term.length > 2 &&
-        !["and", "build", "for", "the", "with", "you", "your"].includes(term) &&
+        !blockedTerms.has(term) &&
         !/^\d+$/.test(term),
     );
 
   return Array.from(new Set([...requirements, ...sourceTerms]))
+    .filter((term) => !blockedTerms.has(term.toLowerCase()))
     .filter(Boolean)
     .slice(0, 5)
     .map(formatFallbackTerm);
@@ -89,24 +145,23 @@ function getFallbackTerms(job: RankedJobSource) {
 export function createRankedMatchDetails(score: number, job: RankedJobSource): RankedMatchDetails {
   const title = job.title?.trim() || "this role";
   const terms = getFallbackTerms(job);
-  const termText = terms.length > 0 ? terms.join(", ") : "the core role requirements";
-  const legacyReason = `Legacy ${title} match: ${score}% fit with posting signals such as ${termText}.`;
+  const termText = formatFallbackTerms(terms, "the core role requirements");
+  const legacyReason = `Legacy ${title} match: ${score}% fit using saved score data.`;
   const recommendation =
-    score >= 80
-      ? `Strong fit for ${title}. Prioritize this role and tailor the resume around ${termText}.`
-      : score >= 60
-        ? `Good fit for ${title}. Worth applying with a tailored resume that reinforces ${termText}.`
-        : score >= 40
-          ? `Moderate fit for ${title}. Consider applying if the role is interesting, but tailor carefully around ${termText}.`
-          : `Weak fit for ${title}. Apply only if there is strong interest or missing resume context.`;
+    score >= 76
+      ? `Strong overlap detected. Prioritize ${title} and tailor the resume toward ${termText}.`
+      : score >= 51
+        ? `Good overlap detected. Tailor the resume toward ${termText} before applying.`
+        : score >= 26
+          ? `Moderate overlap detected. Tailoring the resume toward ${termText} would strengthen the application.`
+          : `Weak overlap detected. Build clearer resume evidence around ${termText} before prioritizing this role.`;
 
   return {
-    strengths:
-      score >= 40 ? [`${title} shows ${score}% fit with posting signals such as ${termText}.`] : [],
+    strengths: score >= 26 ? [`Resume shows some relevant evidence for ${title}.`] : [],
     gaps:
-      score < 60
+      score < 51
         ? [
-            `Before applying to ${title}, verify resume evidence for ${termText}; this legacy match is below the strong-fit range.`,
+            `The application would be stronger with clearer evidence of ${termText}.`,
           ]
         : [],
     reasons: [legacyReason],

--- a/apps/job-coach-web/src/app/api/match/route.test.ts
+++ b/apps/job-coach-web/src/app/api/match/route.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getJobById = vi.fn();
+const from = vi.fn();
+const calculateFit = vi.fn();
+const normalizedResumeToText = vi.fn();
+
+vi.mock("@coach/db", async () => {
+  const actual = await vi.importActual<object>("@coach/db");
+
+  class MockDbJobRepository {
+    getJobById = getJobById;
+  }
+
+  return {
+    ...actual,
+    createServerClient: vi.fn(() => ({ from })),
+    DbJobRepository: MockDbJobRepository,
+  };
+});
+
+vi.mock("@/server/match/normalized-resume-to-text", () => ({
+  normalizedResumeToText,
+}));
+
+vi.mock("../../../server/match/calculate-fit", () => ({
+  calculateFit,
+}));
+
+beforeEach(() => {
+  getJobById.mockReset();
+  from.mockReset();
+  calculateFit.mockReset();
+  normalizedResumeToText.mockReset();
+  vi.resetModules();
+});
+
+function createProfileQuery() {
+  const query = {
+    eq: vi.fn(() => query),
+    order: vi.fn(() => query),
+    limit: vi.fn(() => query),
+    maybeSingle: vi.fn().mockResolvedValue({
+      data: {
+        id: "profile-current",
+        normalized_resume: { basics: { name: "Current Resume" } },
+      },
+      error: null,
+    }),
+  };
+
+  return query;
+}
+
+describe("POST /api/match", () => {
+  it("recalculates fit against the default current resume and upserts match details", async () => {
+    const profileQuery = createProfileQuery();
+    const upsert = vi.fn().mockResolvedValue({ error: null });
+
+    from.mockImplementation((table: string) => {
+      if (table === "resume_profiles") {
+        return {
+          select: vi.fn(() => profileQuery),
+        };
+      }
+
+      if (table === "job_matches") {
+        return { upsert };
+      }
+
+      throw new Error(`Unexpected table: ${table}`);
+    });
+    getJobById.mockResolvedValue({
+      id: "job-1",
+      company: "Pattern",
+      title: "Product Engineer",
+      sourceText: "Build product workflows.",
+    });
+    normalizedResumeToText.mockReturnValue("TypeScript product engineer resume");
+    calculateFit.mockReturnValue({
+      score: 74,
+      reasons: ["Resume evidence overlaps with Product Engineer: TypeScript."],
+      matchDetails: {
+        strengths: ["Resume evidence overlaps with Product Engineer: TypeScript."],
+        gaps: ["Resume evidence is thin for requested areas: Postgres."],
+        reasons: ["Resume evidence overlaps with Product Engineer: TypeScript."],
+        recommendation:
+          "Good fit for Product Engineer. Worth applying with a tailored resume that reinforces TypeScript.",
+      },
+    });
+
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      new Request("http://localhost/api/match", {
+        method: "POST",
+        body: JSON.stringify({ jobId: "job-1", resumeProfileId: "default" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(getJobById).toHaveBeenCalledWith("job-1");
+    expect(profileQuery.eq).not.toHaveBeenCalled();
+    expect(calculateFit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "job-1",
+        company: "Pattern",
+        title: "Product Engineer",
+      }),
+      { rawText: "TypeScript product engineer resume" },
+    );
+    expect(upsert).toHaveBeenCalledWith({
+      job_id: "job-1",
+      resume_profile_id: "profile-current",
+      score: 74,
+      match_details: {
+        strengths: ["Resume evidence overlaps with Product Engineer: TypeScript."],
+        gaps: ["Resume evidence is thin for requested areas: Postgres."],
+        reasons: ["Resume evidence overlaps with Product Engineer: TypeScript."],
+        recommendation:
+          "Good fit for Product Engineer. Worth applying with a tailored resume that reinforces TypeScript.",
+      },
+      created_at: expect.any(String),
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      score: 74,
+      matchDetails: {
+        strengths: ["Resume evidence overlaps with Product Engineer: TypeScript."],
+      },
+    });
+  });
+});

--- a/apps/job-coach-web/src/app/api/match/route.ts
+++ b/apps/job-coach-web/src/app/api/match/route.ts
@@ -77,6 +77,7 @@ export async function POST(request: Request) {
     job_id: body.jobId,
     resume_profile_id: profile?.id ?? null,
     score: result.score,
+    match_details: result.matchDetails,
     created_at: new Date().toISOString(),
   });
 

--- a/apps/job-coach-web/src/app/jobs/jobs-page-client.test.tsx
+++ b/apps/job-coach-web/src/app/jobs/jobs-page-client.test.tsx
@@ -146,6 +146,14 @@ describe("JobsPageClient", () => {
           : new Response(null, { status: 204 });
       }
 
+      if (url === "/api/match" && init?.method === "POST") {
+        return jsonResponse({
+          score: 82,
+          reasons: ["Resume evidence overlaps with Product Engineer: TypeScript."],
+          matchDetails: rankedJob.matchDetails,
+        });
+      }
+
       return jsonResponse({ error: `Unhandled request: ${url}` }, { status: 500 });
     });
 
@@ -620,6 +628,7 @@ describe("JobsPageClient", () => {
     expect(
       within(details).getByRole("menuitem", { name: "Generate Tailored Resume" }),
     ).toBeInTheDocument();
+    expect(within(details).getByRole("menuitem", { name: "Re-assess Fit" })).toBeInTheDocument();
     expect(within(details).getByRole("menuitem", { name: "Edit Details" })).toBeInTheDocument();
     expect(
       within(details).getByRole("menuitem", { name: "Re-import from URL" }),
@@ -629,6 +638,121 @@ describe("JobsPageClient", () => {
       "https://example.com/job",
     );
     expect(within(details).getByRole("menuitem", { name: "Delete Job" })).toBeInTheDocument();
+  });
+
+  it("re-assesses fit from the expanded action menu and refreshes ranked jobs", async () => {
+    let rankedLoadCount = 0;
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+
+      if (url === "/api/jobs/ranked") {
+        rankedLoadCount += 1;
+
+        return jsonResponse([
+          rankedLoadCount === 1
+            ? {
+                ...rankedJob,
+                score: null,
+                matchDetails: null,
+              }
+            : {
+                ...rankedJob,
+                score: 0.74,
+                matchDetails: {
+                  strengths: ["Resume evidence overlaps with Product Engineer: TypeScript."],
+                  gaps: ["Resume evidence is thin for requested areas: Postgres."],
+                  reasons: ["Resume evidence overlaps with Product Engineer: TypeScript."],
+                  recommendation:
+                    "Good fit for Product Engineer. Worth applying with a tailored resume that reinforces TypeScript.",
+                },
+              },
+        ]);
+      }
+
+      if (url === "/api/match" && init?.method === "POST") {
+        return jsonResponse({
+          score: 74,
+          reasons: ["Resume evidence overlaps with Product Engineer: TypeScript."],
+          matchDetails: {
+            strengths: ["Resume evidence overlaps with Product Engineer: TypeScript."],
+            gaps: ["Resume evidence is thin for requested areas: Postgres."],
+            reasons: ["Resume evidence overlaps with Product Engineer: TypeScript."],
+            recommendation:
+              "Good fit for Product Engineer. Worth applying with a tailored resume that reinforces TypeScript.",
+          },
+        });
+      }
+
+      return jsonResponse({ error: `Unhandled request: ${url}` }, { status: 500 });
+    });
+
+    render(<JobsPageClient />);
+
+    expect(await screen.findByText("Not matched")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("job-row"));
+    const details = screen.getByTestId("job-details");
+
+    fireEvent.click(within(details).getByRole("button", { name: "Actions" }));
+    fireEvent.click(within(details).getByRole("menuitem", { name: "Re-assess Fit" }));
+
+    expect(await within(details).findByText("Re-assessing fit...")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/match",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ jobId: "job-1", resumeProfileId: "default" }),
+        }),
+      );
+    });
+
+    expect(await within(details).findByText("Fit re-assessed.")).toBeInTheDocument();
+    expect(await screen.findByText("74%")).toBeInTheDocument();
+
+    fireEvent.click(within(details).getByRole("tab", { name: "Match Details" }));
+    expect(
+      await within(details).findByText("Resume evidence overlaps with Product Engineer: TypeScript."),
+    ).toBeInTheDocument();
+    expect(
+      within(details).getByText("Resume evidence is thin for requested areas: Postgres."),
+    ).toBeInTheDocument();
+    expect(
+      within(details).getByText(
+        "Good fit for Product Engineer. Worth applying with a tailored resume that reinforces TypeScript.",
+      ),
+    ).toBeInTheDocument();
+    expect(rankedLoadCount).toBe(2);
+  });
+
+  it("shows an error when fit re-assessment fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+
+      if (url === "/api/jobs/ranked") {
+        return jsonResponse([rankedJob]);
+      }
+
+      if (url === "/api/match" && init?.method === "POST") {
+        return jsonResponse({ error: "Unable to re-assess fit." }, { status: 500 });
+      }
+
+      return jsonResponse({ error: `Unhandled request: ${url}` }, { status: 500 });
+    });
+
+    render(<JobsPageClient />);
+
+    fireEvent.click(await screen.findByTestId("job-row"));
+    const details = screen.getByTestId("job-details");
+
+    fireEvent.click(within(details).getByRole("button", { name: "Actions" }));
+    fireEvent.click(within(details).getByRole("menuitem", { name: "Re-assess Fit" }));
+
+    expect(await within(details).findByText("Unable to re-assess fit.")).toBeInTheDocument();
   });
 
   it("renders structured and original posting details with expanded-card controls", async () => {

--- a/apps/job-coach-web/src/app/jobs/jobs-page-client.test.tsx
+++ b/apps/job-coach-web/src/app/jobs/jobs-page-client.test.tsx
@@ -610,7 +610,7 @@ describe("JobsPageClient", () => {
     expect(screen.queryByTestId("job-details")).not.toBeInTheDocument();
   });
 
-  it("shows job actions only inside the expanded action menu", async () => {
+  it("shows job actions only after opening the expanded action menu", async () => {
     render(<JobsPageClient />);
 
     expect(await screen.findByText("Product Engineer")).toBeInTheDocument();
@@ -625,19 +625,78 @@ describe("JobsPageClient", () => {
 
     fireEvent.click(within(details).getByRole("button", { name: "Actions" }));
 
-    expect(
-      within(details).getByRole("menuitem", { name: "Generate Tailored Resume" }),
-    ).toBeInTheDocument();
-    expect(within(details).getByRole("menuitem", { name: "Re-assess Fit" })).toBeInTheDocument();
-    expect(within(details).getByRole("menuitem", { name: "Edit Details" })).toBeInTheDocument();
-    expect(
-      within(details).getByRole("menuitem", { name: "Re-import from URL" }),
-    ).toBeInTheDocument();
-    expect(within(details).getByRole("menuitem", { name: "View Job Posting" })).toHaveAttribute(
+    expect(screen.getByTestId("job-actions-menu")).toHaveAttribute("data-side", "down");
+    expect(screen.getByRole("menuitem", { name: "Generate Tailored Resume" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Re-assess Fit" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Edit Details" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Re-import from URL" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "View Job Posting" })).toHaveAttribute(
       "href",
       "https://example.com/job",
     );
-    expect(within(details).getByRole("menuitem", { name: "Delete Job" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Delete Job" })).toBeInTheDocument();
+  });
+
+  it("positions the action menu upward when there is not enough viewport space below", async () => {
+    const originalInnerHeight = window.innerHeight;
+    const originalInnerWidth = window.innerWidth;
+    const rectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect");
+
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 640 });
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1024 });
+    rectSpy.mockImplementation(function getMockRect(this: HTMLElement) {
+      if (this.textContent === "Actions") {
+        return {
+          bottom: 620,
+          height: 32,
+          left: 832,
+          right: 912,
+          top: 588,
+          width: 80,
+          x: 832,
+          y: 588,
+          toJSON: () => undefined,
+        };
+      }
+
+      if (this.getAttribute("data-testid") === "job-actions-menu") {
+        return {
+          bottom: 240,
+          height: 240,
+          left: 0,
+          right: 192,
+          top: 0,
+          width: 192,
+          x: 0,
+          y: 0,
+          toJSON: () => undefined,
+        };
+      }
+
+      return {
+        bottom: 0,
+        height: 0,
+        left: 0,
+        right: 0,
+        top: 0,
+        width: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => undefined,
+      };
+    });
+
+    render(<JobsPageClient />);
+
+    fireEvent.click(await screen.findByTestId("job-row"));
+    fireEvent.click(within(screen.getByTestId("job-details")).getByRole("button", { name: "Actions" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("job-actions-menu")).toHaveAttribute("data-side", "up");
+    });
+
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: originalInnerHeight });
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: originalInnerWidth });
   });
 
   it("re-assesses fit from the expanded action menu and refreshes ranked jobs", async () => {
@@ -701,7 +760,7 @@ describe("JobsPageClient", () => {
     const details = screen.getByTestId("job-details");
 
     fireEvent.click(within(details).getByRole("button", { name: "Actions" }));
-    fireEvent.click(within(details).getByRole("menuitem", { name: "Re-assess Fit" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Re-assess Fit" }));
 
     expect(await within(details).findByText("Re-assessing fit...")).toBeInTheDocument();
 
@@ -760,7 +819,7 @@ describe("JobsPageClient", () => {
     const details = screen.getByTestId("job-details");
 
     fireEvent.click(within(details).getByRole("button", { name: "Actions" }));
-    fireEvent.click(within(details).getByRole("menuitem", { name: "Re-assess Fit" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Re-assess Fit" }));
 
     expect(await within(details).findByText("Unable to re-assess fit.")).toBeInTheDocument();
   });
@@ -891,9 +950,7 @@ describe("JobsPageClient", () => {
     fireEvent.click(
       within(screen.getByTestId("job-details")).getByRole("button", { name: "Actions" }),
     );
-    fireEvent.click(
-      within(screen.getByTestId("job-details")).getByRole("menuitem", { name: "Delete Job" }),
-    );
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete Job" }));
 
     expect(confirmSpy).toHaveBeenCalledWith("Delete this job? This cannot be undone.");
     expect(fetchMock).not.toHaveBeenCalledWith(
@@ -913,9 +970,7 @@ describe("JobsPageClient", () => {
     fireEvent.click(
       within(screen.getByTestId("job-details")).getByRole("button", { name: "Actions" }),
     );
-    fireEvent.click(
-      within(screen.getByTestId("job-details")).getByRole("menuitem", { name: "Delete Job" }),
-    );
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete Job" }));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -946,9 +1001,7 @@ describe("JobsPageClient", () => {
     fireEvent.click(
       within(screen.getByTestId("job-details")).getByRole("button", { name: "Actions" }),
     );
-    fireEvent.click(
-      within(screen.getByTestId("job-details")).getByRole("menuitem", { name: "Delete Job" }),
-    );
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete Job" }));
 
     expect(await screen.findByText("Unable to delete job.")).toBeInTheDocument();
     expect(screen.getByText("Product Engineer")).toBeInTheDocument();
@@ -971,7 +1024,7 @@ describe("JobsPageClient", () => {
     expect(screen.queryByLabelText("Resume profile")).not.toBeInTheDocument();
 
     fireEvent.click(within(details).getByRole("button", { name: "Actions" }));
-    fireEvent.click(within(details).getByRole("menuitem", { name: "Generate Tailored Resume" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Generate Tailored Resume" }));
 
     expect(
       await screen.findByRole("dialog", { name: "Generate tailored resume" }),

--- a/apps/job-coach-web/src/app/jobs/jobs-page-client.test.tsx
+++ b/apps/job-coach-web/src/app/jobs/jobs-page-client.test.tsx
@@ -660,11 +660,17 @@ describe("JobsPageClient", () => {
                 ...rankedJob,
                 score: 0.74,
                 matchDetails: {
-                  strengths: ["Resume evidence overlaps with Product Engineer: TypeScript."],
-                  gaps: ["Resume evidence is thin for requested areas: Postgres."],
-                  reasons: ["Resume evidence overlaps with Product Engineer: TypeScript."],
+                  strengths: [
+                    "Resume shows relevant evidence around TypeScript for Product Engineer.",
+                  ],
+                  gaps: [
+                    "The application would be stronger with clearer evidence of Postgres.",
+                  ],
+                  reasons: [
+                    "Resume shows relevant evidence around TypeScript for Product Engineer.",
+                  ],
                   recommendation:
-                    "Good fit for Product Engineer. Worth applying with a tailored resume that reinforces TypeScript.",
+                    "Good overlap detected. Tailor the resume toward TypeScript before applying.",
                 },
               },
         ]);
@@ -673,13 +679,13 @@ describe("JobsPageClient", () => {
       if (url === "/api/match" && init?.method === "POST") {
         return jsonResponse({
           score: 74,
-          reasons: ["Resume evidence overlaps with Product Engineer: TypeScript."],
+          reasons: ["Resume shows relevant evidence around TypeScript for Product Engineer."],
           matchDetails: {
-            strengths: ["Resume evidence overlaps with Product Engineer: TypeScript."],
-            gaps: ["Resume evidence is thin for requested areas: Postgres."],
-            reasons: ["Resume evidence overlaps with Product Engineer: TypeScript."],
+            strengths: ["Resume shows relevant evidence around TypeScript for Product Engineer."],
+            gaps: ["The application would be stronger with clearer evidence of Postgres."],
+            reasons: ["Resume shows relevant evidence around TypeScript for Product Engineer."],
             recommendation:
-              "Good fit for Product Engineer. Worth applying with a tailored resume that reinforces TypeScript.",
+              "Good overlap detected. Tailor the resume toward TypeScript before applying.",
           },
         });
       }
@@ -714,14 +720,18 @@ describe("JobsPageClient", () => {
 
     fireEvent.click(within(details).getByRole("tab", { name: "Match Details" }));
     expect(
-      await within(details).findByText("Resume evidence overlaps with Product Engineer: TypeScript."),
-    ).toBeInTheDocument();
-    expect(
-      within(details).getByText("Resume evidence is thin for requested areas: Postgres."),
+      await within(details).findByText(
+        "Resume shows relevant evidence around TypeScript for Product Engineer.",
+      ),
     ).toBeInTheDocument();
     expect(
       within(details).getByText(
-        "Good fit for Product Engineer. Worth applying with a tailored resume that reinforces TypeScript.",
+        "The application would be stronger with clearer evidence of Postgres.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(details).getByText(
+        "Good overlap detected. Tailor the resume toward TypeScript before applying.",
       ),
     ).toBeInTheDocument();
     expect(rankedLoadCount).toBe(2);
@@ -836,6 +846,40 @@ describe("JobsPageClient", () => {
     expect(
       within(details).getByText("Not enough information to generate a recommendation."),
     ).toBeInTheDocument();
+  });
+
+  it("labels a 36 percent fit as a moderate match", async () => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+
+      if (url === "/api/jobs/ranked") {
+        return jsonResponse([
+          {
+            ...rankedJob,
+            score: 0.36,
+            matchDetails: null,
+          },
+        ]);
+      }
+
+      return jsonResponse({ error: `Unhandled request: ${url}` }, { status: 500 });
+    });
+
+    render(<JobsPageClient />);
+
+    fireEvent.click(await screen.findByTestId("job-row"));
+    const details = screen.getByTestId("job-details");
+
+    fireEvent.click(within(details).getByRole("tab", { name: "Match Details" }));
+
+    expect(within(details).getByText("Fit: 36%")).toBeInTheDocument();
+    expect(within(details).getByText("Moderate Match")).toBeInTheDocument();
+    expect(
+      within(details).getByText(
+        "Moderate overlap detected. Tailoring the resume toward the role requirements would strengthen the application.",
+      ),
+    ).toBeInTheDocument();
+    expect(within(details).queryByText(/apply only if/i)).not.toBeInTheDocument();
   });
 
   it("does not delete the job when confirmation is canceled", async () => {

--- a/apps/job-coach-web/src/app/jobs/jobs-page-client.test.tsx
+++ b/apps/job-coach-web/src/app/jobs/jobs-page-client.test.tsx
@@ -52,9 +52,10 @@ describe("JobsPageClient", () => {
     matchDetails: {
       strengths: ["Strong TypeScript alignment"],
       gaps: ["No explicit Postgres signal"],
-      reasons: ["Good keyword overlap"],
+      reasons: ["Resume evidence overlaps with Product Engineer: TypeScript, product workflows."],
       summary: "Strong fit for product workflow work.",
-      recommendation: "apply",
+      recommendation:
+        "Strong fit for Product Engineer. Prioritize this role and tailor the resume around TypeScript and product workflows.",
     },
   };
 
@@ -672,7 +673,7 @@ describe("JobsPageClient", () => {
     expect(within(details).getByText("Recommendation")).toBeInTheDocument();
     expect(
       within(details).getByText(
-        "Strong fit. Prioritize this role and tailor the resume around the strongest matches.",
+        "Strong fit for Product Engineer. Prioritize this role and tailor the resume around TypeScript and product workflows.",
       ),
     ).toBeInTheDocument();
     expect(

--- a/apps/job-coach-web/src/app/jobs/jobs-page-client.tsx
+++ b/apps/job-coach-web/src/app/jobs/jobs-page-client.tsx
@@ -9,6 +9,7 @@ import {
   ColumnDef,
   SortingState,
 } from "@tanstack/react-table";
+import { createPortal } from "react-dom";
 
 import { getMatchScoreState } from "@/lib/jobs-table-signals";
 
@@ -69,6 +70,12 @@ type TailoredResumeResult = {
   name: string;
   profileId: string;
   versionId: string;
+};
+
+type ActionsMenuPosition = {
+  direction: "down" | "up";
+  left: number;
+  top: number;
 };
 
 const jobDateFormatter = new Intl.DateTimeFormat("en-US", {
@@ -689,6 +696,9 @@ function JobDetailsPanel({
   const [reassessState, setReassessState] = useState<"idle" | "loading" | "success" | "error">(
     "idle",
   );
+  const actionsButtonRef = React.useRef<HTMLButtonElement | null>(null);
+  const actionsMenuRef = React.useRef<HTMLDivElement | null>(null);
+  const [actionsMenuPosition, setActionsMenuPosition] = useState<ActionsMenuPosition | null>(null);
   const structuredPanelId = `job-${job.id}-structured-view`;
   const rawPanelId = `job-${job.id}-original-posting`;
   const matchPanelId = `job-${job.id}-match-details`;
@@ -714,8 +724,132 @@ function JobDetailsPanel({
     }
   }
 
+  const updateActionsMenuPosition = useCallback(() => {
+    const button = actionsButtonRef.current;
+    const menu = actionsMenuRef.current;
+
+    if (!button || !menu) {
+      return;
+    }
+
+    const viewportMargin = 8;
+    const menuGap = 8;
+    const menuWidth = 192;
+    const buttonRect = button.getBoundingClientRect();
+    const menuRect = menu.getBoundingClientRect();
+    const menuHeight = menuRect.height;
+    const spaceBelow = window.innerHeight - buttonRect.bottom;
+    const spaceAbove = buttonRect.top;
+    const direction =
+      spaceBelow < menuHeight + menuGap && spaceAbove > spaceBelow ? "up" : "down";
+    const preferredTop =
+      direction === "up" ? buttonRect.top - menuHeight - menuGap : buttonRect.bottom + menuGap;
+    const maxTop = Math.max(viewportMargin, window.innerHeight - menuHeight - viewportMargin);
+    const maxLeft = Math.max(viewportMargin, window.innerWidth - menuWidth - viewportMargin);
+
+    setActionsMenuPosition({
+      direction,
+      left: Math.min(Math.max(viewportMargin, buttonRect.right - menuWidth), maxLeft),
+      top: Math.min(Math.max(viewportMargin, preferredTop), maxTop),
+    });
+  }, []);
+
+  React.useLayoutEffect(() => {
+    if (!actionsOpen) {
+      setActionsMenuPosition(null);
+      return;
+    }
+
+    updateActionsMenuPosition();
+
+    window.addEventListener("resize", updateActionsMenuPosition);
+    window.addEventListener("scroll", updateActionsMenuPosition, true);
+
+    return () => {
+      window.removeEventListener("resize", updateActionsMenuPosition);
+      window.removeEventListener("scroll", updateActionsMenuPosition, true);
+    };
+  }, [actionsOpen, updateActionsMenuPosition]);
+
+  const actionsMenu = actionsOpen
+    ? createPortal(
+        <div
+          ref={actionsMenuRef}
+          role="menu"
+          data-testid="job-actions-menu"
+          data-side={actionsMenuPosition?.direction ?? "down"}
+          className="fixed z-50 w-48 overflow-hidden rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+          style={{
+            left: actionsMenuPosition?.left ?? 0,
+            top: actionsMenuPosition?.top ?? 0,
+            visibility: actionsMenuPosition ? "visible" : "hidden",
+          }}
+        >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setResumeTailorOpen(true);
+              setActionsOpen(false);
+            }}
+            className="w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+          >
+            Generate Tailored Resume
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            disabled={reassessState === "loading"}
+            onClick={() => {
+              void handleReassessClick();
+            }}
+            className="w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {reassessState === "loading" ? "Re-assessing Fit..." : "Re-assess Fit"}
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setEditDetailsOpen(true);
+              setActionsOpen(false);
+            }}
+            className="w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+          >
+            Edit Details
+          </button>
+          <div>
+            <ReimportJobPanel jobId={job.id} sourceUrl={job.sourceUrl} variant="menu-item" />
+          </div>
+          {job.sourceUrl ? (
+            <a
+              href={job.sourceUrl}
+              target="_blank"
+              role="menuitem"
+              onClick={() => setActionsOpen(false)}
+              className="block w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+            >
+              View Job Posting
+            </a>
+          ) : null}
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setActionsOpen(false);
+              void onDeleteJob(job.id);
+            }}
+            className="w-full border-t border-gray-100 px-3 py-2 text-left text-sm font-medium text-red-700 hover:bg-red-50"
+          >
+            Delete Job
+          </button>
+        </div>,
+        document.body,
+      )
+    : null;
+
   return (
-    <div className="mt-4 overflow-hidden rounded-lg border border-gray-200 bg-white">
+    <div className="mt-4 rounded-lg border border-gray-200 bg-white">
       <div className="flex flex-wrap items-center justify-between gap-3 bg-gray-50 px-4 py-3">
         <div>
           <h3 className="text-sm font-semibold text-gray-900">Job Details</h3>
@@ -729,6 +863,7 @@ function JobDetailsPanel({
         </div>
         <div className="relative">
           <button
+            ref={actionsButtonRef}
             type="button"
             aria-expanded={actionsOpen}
             aria-haspopup="menu"
@@ -738,71 +873,7 @@ function JobDetailsPanel({
             Actions
           </button>
 
-          {actionsOpen ? (
-            <div
-              role="menu"
-              className="absolute right-0 z-20 mt-2 w-48 overflow-hidden rounded-md border border-gray-200 bg-white py-1 shadow-lg"
-            >
-              <button
-                type="button"
-                role="menuitem"
-                onClick={() => {
-                  setResumeTailorOpen(true);
-                  setActionsOpen(false);
-                }}
-                className="w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
-              >
-                Generate Tailored Resume
-              </button>
-              <button
-                type="button"
-                role="menuitem"
-                disabled={reassessState === "loading"}
-                onClick={() => {
-                  void handleReassessClick();
-                }}
-                className="w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {reassessState === "loading" ? "Re-assessing Fit..." : "Re-assess Fit"}
-              </button>
-              <button
-                type="button"
-                role="menuitem"
-                onClick={() => {
-                  setEditDetailsOpen(true);
-                  setActionsOpen(false);
-                }}
-                className="w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
-              >
-                Edit Details
-              </button>
-              <div>
-                <ReimportJobPanel jobId={job.id} sourceUrl={job.sourceUrl} variant="menu-item" />
-              </div>
-              {job.sourceUrl ? (
-                <a
-                  href={job.sourceUrl}
-                  target="_blank"
-                  role="menuitem"
-                  onClick={() => setActionsOpen(false)}
-                  className="block w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
-                >
-                  View Job Posting
-                </a>
-              ) : null}
-              <button
-                type="button"
-                role="menuitem"
-                onClick={() => {
-                  setActionsOpen(false);
-                  void onDeleteJob(job.id);
-                }}
-                className="w-full border-t border-gray-100 px-3 py-2 text-left text-sm font-medium text-red-700 hover:bg-red-50"
-              >
-                Delete Job
-              </button>
-            </div>
-          ) : null}
+          {actionsMenu}
         </div>
       </div>
 

--- a/apps/job-coach-web/src/app/jobs/jobs-page-client.tsx
+++ b/apps/job-coach-web/src/app/jobs/jobs-page-client.tsx
@@ -891,9 +891,9 @@ function getFitLabel(score: number | null) {
 
   const percentage = Math.round(score * 100);
 
-  if (percentage >= 80) return "Strong Match";
-  if (percentage >= 60) return "Good Match";
-  if (percentage >= 40) return "Moderate Match";
+  if (percentage >= 76) return "Strong Match";
+  if (percentage >= 51) return "Good Match";
+  if (percentage >= 26) return "Moderate Match";
   return "Weak Match";
 }
 
@@ -902,19 +902,19 @@ function getFitRecommendation(score: number | null) {
 
   const percentage = Math.round(score * 100);
 
-  if (percentage >= 80) {
-    return "Strong fit. Prioritize this role and tailor the resume around the strongest matches.";
+  if (percentage >= 76) {
+    return "Strong overlap detected. Prioritize this role and tailor the resume toward the strongest evidence.";
   }
 
-  if (percentage >= 60) {
-    return "Good fit. Worth applying with a tailored resume.";
+  if (percentage >= 51) {
+    return "Good overlap detected. Tailor the resume toward the strongest role signals before applying.";
   }
 
-  if (percentage >= 40) {
-    return "Moderate fit. Consider applying if the role is interesting, but tailor carefully around gaps.";
+  if (percentage >= 26) {
+    return "Moderate overlap detected. Tailoring the resume toward the role requirements would strengthen the application.";
   }
 
-  return "Weak fit. Apply only if there is strong interest or missing resume context.";
+  return "Weak overlap detected. Build clearer resume evidence before prioritizing this role.";
 }
 
 function MatchDetailList({ items, fallback }: { items: string[]; fallback: string }) {

--- a/apps/job-coach-web/src/app/jobs/jobs-page-client.tsx
+++ b/apps/job-coach-web/src/app/jobs/jobs-page-client.tsx
@@ -204,6 +204,23 @@ export function JobsPageClient() {
     }
   }
 
+  const handleReassessFit = useCallback(
+    async (jobId: string) => {
+      const res = await fetch("/api/match", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jobId, resumeProfileId: "default" }),
+      });
+
+      if (!res.ok) {
+        throw new Error("Re-assess fit failed.");
+      }
+
+      await load();
+    },
+    [load],
+  );
+
   const handleUpdateJobDetails = useCallback(
     async (jobId: string, input: { company: string; title: string }) => {
       const company = input.company.trim();
@@ -536,6 +553,7 @@ export function JobsPageClient() {
                           <JobDetailsPanel
                             job={row.original}
                             onDeleteJob={handleDeleteJob}
+                            onReassessFit={handleReassessFit}
                             onUpdateJobDetails={handleUpdateJobDetails}
                           />
                         </td>
@@ -656,16 +674,21 @@ function JobsTableSkeleton() {
 function JobDetailsPanel({
   job,
   onDeleteJob,
+  onReassessFit,
   onUpdateJobDetails,
 }: {
   job: RankedJob;
   onDeleteJob: (jobId: string) => void | Promise<void>;
+  onReassessFit: (jobId: string) => Promise<void>;
   onUpdateJobDetails: (jobId: string, input: { company: string; title: string }) => Promise<void>;
 }) {
   const [mode, setMode] = useState<JobDetailMode>("structured");
   const [resumeTailorOpen, setResumeTailorOpen] = useState(false);
   const [actionsOpen, setActionsOpen] = useState(false);
   const [editDetailsOpen, setEditDetailsOpen] = useState(false);
+  const [reassessState, setReassessState] = useState<"idle" | "loading" | "success" | "error">(
+    "idle",
+  );
   const structuredPanelId = `job-${job.id}-structured-view`;
   const rawPanelId = `job-${job.id}-original-posting`;
   const matchPanelId = `job-${job.id}-match-details`;
@@ -678,10 +701,32 @@ function JobDetailsPanel({
         : "border-transparent font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-800"
     }`;
 
+  async function handleReassessClick() {
+    setActionsOpen(false);
+    setReassessState("loading");
+
+    try {
+      await onReassessFit(job.id);
+      setReassessState("success");
+    } catch (error) {
+      console.error(error);
+      setReassessState("error");
+    }
+  }
+
   return (
     <div className="mt-4 overflow-hidden rounded-lg border border-gray-200 bg-white">
       <div className="flex flex-wrap items-center justify-between gap-3 bg-gray-50 px-4 py-3">
-        <h3 className="text-sm font-semibold text-gray-900">Job Details</h3>
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900">Job Details</h3>
+          {reassessState === "loading" ? (
+            <p className="mt-1 text-xs text-gray-600">Re-assessing fit...</p>
+          ) : reassessState === "success" ? (
+            <p className="mt-1 text-xs text-green-700">Fit re-assessed.</p>
+          ) : reassessState === "error" ? (
+            <p className="mt-1 text-xs text-red-700">Unable to re-assess fit.</p>
+          ) : null}
+        </div>
         <div className="relative">
           <button
             type="button"
@@ -708,6 +753,17 @@ function JobDetailsPanel({
                 className="w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
               >
                 Generate Tailored Resume
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                disabled={reassessState === "loading"}
+                onClick={() => {
+                  void handleReassessClick();
+                }}
+                className="w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {reassessState === "loading" ? "Re-assessing Fit..." : "Re-assess Fit"}
               </button>
               <button
                 type="button"

--- a/apps/job-coach-web/src/app/jobs/jobs-page-client.tsx
+++ b/apps/job-coach-web/src/app/jobs/jobs-page-client.tsx
@@ -906,9 +906,10 @@ function JobMatchDetails({
   const gaps = getMatchDetailItems(matchDetails?.gaps);
   const reasons = getMatchDetailItems(matchDetails?.reasons);
   const summary = getMatchDetailText(matchDetails?.summary);
+  const savedRecommendation = getMatchDetailText(matchDetails?.recommendation);
   const fallbackStrengths = strengths.length === 0 && gaps.length === 0 ? reasons : [];
   const fitLabel = getFitLabel(score);
-  const fitRecommendation = getFitRecommendation(score);
+  const fitRecommendation = savedRecommendation ?? getFitRecommendation(score);
 
   return (
     <div className="flex max-w-4xl flex-col gap-4">

--- a/apps/job-coach-web/src/server/jobs/reimport-job.test.ts
+++ b/apps/job-coach-web/src/server/jobs/reimport-job.test.ts
@@ -212,6 +212,12 @@ describe("applyJobReimport", () => {
         job_id: "job-123",
         resume_profile_id: "profile-1",
         score: expect.any(Number),
+        match_details: {
+          strengths: expect.any(Array),
+          gaps: expect.any(Array),
+          reasons: expect.any(Array),
+          recommendation: expect.any(String),
+        },
       }),
     );
     expect(result.job).toMatchObject({

--- a/apps/job-coach-web/src/server/jobs/reimport-job.ts
+++ b/apps/job-coach-web/src/server/jobs/reimport-job.ts
@@ -221,6 +221,7 @@ async function upsertJobMatch(
     job_id: job.id,
     resume_profile_id: resolvedResumeProfileId,
     score: result.score,
+    match_details: result.matchDetails,
     created_at: new Date().toISOString(),
   });
 

--- a/apps/job-coach-web/src/server/match/backfill-job-matches.test.ts
+++ b/apps/job-coach-web/src/server/match/backfill-job-matches.test.ts
@@ -71,6 +71,12 @@ describe("backfillJobMatches", () => {
     expect(rows[0]).toMatchObject({
       job_id: "job-1",
       resume_profile_id: "profile-1",
+      match_details: {
+        strengths: expect.any(Array),
+        gaps: expect.any(Array),
+        reasons: expect.any(Array),
+        recommendation: expect.any(String),
+      },
     });
     expect(typeof rows[0].score).toBe("number");
     expect(typeof rows[1].score).toBe("number");

--- a/apps/job-coach-web/src/server/match/backfill-job-matches.ts
+++ b/apps/job-coach-web/src/server/match/backfill-job-matches.ts
@@ -63,6 +63,7 @@ export async function backfillJobMatches(db: SupabaseClient) {
       job_id: job.id,
       resume_profile_id: resumeProfileId,
       score: result.score,
+      match_details: result.matchDetails,
       created_at: new Date().toISOString(),
     };
   });

--- a/apps/job-coach-web/src/server/match/calculate-fit.test.ts
+++ b/apps/job-coach-web/src/server/match/calculate-fit.test.ts
@@ -17,7 +17,52 @@ describe("calculateFit", () => {
 
     expect(result.score).toBeGreaterThan(0);
     expect(result.matchDetails.strengths.join(" ")).toContain("Staff Product Engineer");
-    expect(result.matchDetails.recommendation).toContain("Staff Product Engineer");
+    expect(result.matchDetails.recommendation).toContain("TypeScript");
     expect(result.matchDetails.reasons.join(" ")).not.toContain("Good keyword overlap");
+  });
+
+  it("filters noisy business terms and prefers useful coaching signals", () => {
+    const result = calculateFit(
+      {
+        title: "Staff Software Engineer",
+        company: "Predict",
+        sourceText:
+          "Join our job-obsessed partner team. Use predictive analytics, APIs, data, and platform work for product-domain outcomes.",
+      },
+      {
+        rawText: "Staff software engineer with data analytics, APIs, and platform experience.",
+      },
+    );
+    const details = [
+      ...result.matchDetails.strengths,
+      ...result.matchDetails.gaps,
+      result.matchDetails.recommendation,
+    ].join(" ");
+
+    expect(details).toContain("data");
+    expect(details).toContain("APIs");
+    expect(details).toContain("platform");
+    expect(details).not.toMatch(/\b(obsessed|partner|job|predict)\b/i);
+    expect(details).not.toContain("Good keyword overlap");
+    expect(details).not.toContain("Resume evidence is thin for requested areas");
+  });
+
+  it("treats mid-thirties scores as moderate coaching opportunities", () => {
+    const result = calculateFit(
+      {
+        title: "Analytics Engineer",
+        company: "Pattern",
+        sourceText:
+          "predictive analytics data platform APIs React TypeScript healthcare fintech distributed systems",
+      },
+      {
+        rawText: "predictive analytics data product",
+      },
+    );
+
+    expect(result.score).toBeGreaterThanOrEqual(26);
+    expect(result.score).toBeLessThanOrEqual(50);
+    expect(result.matchDetails.recommendation).toContain("Moderate overlap detected");
+    expect(result.matchDetails.recommendation).not.toContain("Apply only if");
   });
 });

--- a/apps/job-coach-web/src/server/match/calculate-fit.test.ts
+++ b/apps/job-coach-web/src/server/match/calculate-fit.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateFit } from "./calculate-fit";
+
+describe("calculateFit", () => {
+  it("returns role-specific match details without generic overlap wording", () => {
+    const result = calculateFit(
+      {
+        title: "Staff Product Engineer",
+        company: "Pattern",
+        sourceText: "TypeScript React product workflows and platform leadership",
+      },
+      {
+        rawText: "Staff engineer with TypeScript React platform leadership experience.",
+      },
+    );
+
+    expect(result.score).toBeGreaterThan(0);
+    expect(result.matchDetails.strengths.join(" ")).toContain("Staff Product Engineer");
+    expect(result.matchDetails.recommendation).toContain("Staff Product Engineer");
+    expect(result.matchDetails.reasons.join(" ")).not.toContain("Good keyword overlap");
+  });
+});

--- a/apps/job-coach-web/src/server/match/calculate-fit.ts
+++ b/apps/job-coach-web/src/server/match/calculate-fit.ts
@@ -1,12 +1,19 @@
 export type FitResult = {
   score: number;
   reasons: string[];
+  matchDetails: {
+    strengths: string[];
+    gaps: string[];
+    reasons: string[];
+    recommendation: string;
+  };
 };
 
 type Job = {
   title?: string;
   company?: string;
   sourceText?: string;
+  structuredSummary?: unknown;
 };
 
 type Resume = {
@@ -31,6 +38,97 @@ function overlap(a: string[], b: string[]): number {
   return a.length ? hits / a.length : 0;
 }
 
+const STOP_WORDS = new Set([
+  "about",
+  "and",
+  "are",
+  "for",
+  "from",
+  "have",
+  "our",
+  "that",
+  "the",
+  "this",
+  "with",
+  "you",
+  "your",
+]);
+
+function uniqueMeaningfulTokens(tokens: string[]) {
+  return Array.from(
+    new Set(
+      tokens.filter((token) => token.length > 2 && !STOP_WORDS.has(token) && !/^\d+$/.test(token)),
+    ),
+  );
+}
+
+function formatTerms(terms: string[]) {
+  return terms
+    .slice(0, 5)
+    .map((term) => term.replace(/\b\w/g, (letter) => letter.toUpperCase()))
+    .join(", ");
+}
+
+function getSenioritySignal(text: string) {
+  const lower = text.toLowerCase();
+
+  if (/\b(staff|principal|lead|senior|sr)\b/.test(lower)) return "senior";
+  if (/\b(junior|jr|entry)\b/.test(lower)) return "junior";
+
+  return null;
+}
+
+function createMatchDetails(job: Job, resumeText: string, score: number) {
+  const title = job.title?.trim() || "this role";
+  const jobTokens = uniqueMeaningfulTokens(
+    tokenize(
+      [job.title, job.company, job.sourceText, JSON.stringify(job.structuredSummary ?? "")]
+        .filter(Boolean)
+        .join(" "),
+    ),
+  );
+  const resumeTokens = new Set(uniqueMeaningfulTokens(tokenize(resumeText)));
+  const matchedTerms = jobTokens.filter((token) => resumeTokens.has(token));
+  const missingTerms = jobTokens.filter((token) => !resumeTokens.has(token));
+  const strengths: string[] = [];
+  const gaps: string[] = [];
+
+  if (matchedTerms.length > 0) {
+    strengths.push(`Resume evidence overlaps with ${title}: ${formatTerms(matchedTerms)}.`);
+  }
+
+  const seniority = getSenioritySignal([job.title, job.sourceText].filter(Boolean).join(" "));
+  if (seniority && getSenioritySignal(resumeText) === seniority) {
+    strengths.push(`Seniority signal appears aligned for a ${seniority}-level role.`);
+  } else if (seniority) {
+    gaps.push(`Seniority alignment is unclear for a ${seniority}-level role.`);
+  }
+
+  if (missingTerms.length > 0) {
+    gaps.push(`Resume evidence is thin for requested areas: ${formatTerms(missingTerms)}.`);
+  }
+
+  if (strengths.length === 0) {
+    strengths.push(`No strong resume overlap was found for ${title} in the current resume text.`);
+  }
+
+  if (gaps.length === 0 && score > 0) {
+    gaps.push("No major keyword gaps were found in the current resume text.");
+  }
+
+  const reasons = [...strengths, ...gaps];
+  const recommendation =
+    score >= 80
+      ? `Strong fit for ${title}. Prioritize this role and tailor the resume around the strongest matches.`
+      : score >= 60
+        ? `Good fit for ${title}. Worth applying with a tailored resume that reinforces the strongest overlaps.`
+        : score >= 40
+          ? `Moderate fit for ${title}. Consider applying if the role is interesting, but tailor carefully around the gaps.`
+          : `Weak fit for ${title}. Apply only if there is strong interest or missing resume context.`;
+
+  return { strengths, gaps, reasons, recommendation };
+}
+
 export function calculateFit(job: Job, resume: Resume): FitResult {
   const jobText = [job.title, job.company, job.sourceText].filter(Boolean).join(" ");
 
@@ -40,9 +138,11 @@ export function calculateFit(job: Job, resume: Resume): FitResult {
   const resumeTokens = tokenize(resumeText);
 
   const score = Math.round(overlap(jobTokens, resumeTokens) * 100);
+  const matchDetails = createMatchDetails(job, resumeText, score);
 
   return {
     score,
-    reasons: score > 30 ? ["Good keyword overlap"] : ["Low keyword overlap"],
+    reasons: matchDetails.reasons,
+    matchDetails,
   };
 }

--- a/apps/job-coach-web/src/server/match/calculate-fit.ts
+++ b/apps/job-coach-web/src/server/match/calculate-fit.ts
@@ -42,31 +42,123 @@ const STOP_WORDS = new Set([
   "about",
   "and",
   "are",
+  "company",
+  "culture",
+  "dynamic",
+  "engineer",
+  "engineering",
+  "fast",
   "for",
   "from",
   "have",
+  "job",
+  "mission",
+  "obsessed",
+  "opportunity",
   "our",
+  "partner",
+  "passionate",
   "that",
   "the",
   "this",
+  "team",
+  "use",
   "with",
+  "world",
   "you",
   "your",
 ]);
 
-function uniqueMeaningfulTokens(tokens: string[]) {
+const SIGNAL_PHRASES = [
+  "distributed systems",
+  "machine learning",
+  "predictive analytics",
+  "product engineering",
+  "typeScript",
+  "healthcare",
+  "analytics",
+  "fintech",
+  "platform",
+  "react",
+  "apis",
+  "data",
+  "ml",
+  "ai",
+];
+
+const TERM_LABELS: Record<string, string> = {
+  ai: "AI",
+  apis: "APIs",
+  data: "data",
+  fintech: "fintech",
+  healthcare: "healthcare",
+  ml: "ML",
+  platform: "platform",
+  react: "React",
+  typescript: "TypeScript",
+};
+
+function uniqueMeaningfulTokens(tokens: string[], ignoredTokens: Set<string> = new Set()) {
   return Array.from(
     new Set(
-      tokens.filter((token) => token.length > 2 && !STOP_WORDS.has(token) && !/^\d+$/.test(token)),
+      tokens.filter(
+        (token) =>
+          token.length > 2 &&
+          !STOP_WORDS.has(token) &&
+          !ignoredTokens.has(token) &&
+          !/^\d+$/.test(token),
+      ),
     ),
   );
 }
 
-function formatTerms(terms: string[]) {
-  return terms
+function formatTerm(term: string) {
+  return TERM_LABELS[term] ?? term.replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function formatTerms(terms: string[], fallback: string) {
+  const formatted = terms
     .slice(0, 5)
-    .map((term) => term.replace(/\b\w/g, (letter) => letter.toUpperCase()))
-    .join(", ");
+    .map(formatTerm)
+    .filter(Boolean);
+
+  if (formatted.length === 0) {
+    return fallback;
+  }
+
+  if (formatted.length === 1) {
+    return formatted[0];
+  }
+
+  return `${formatted.slice(0, -1).join(", ")} and ${formatted[formatted.length - 1]}`;
+}
+
+function getSignalPhrases(text: string) {
+  const lower = text.toLowerCase();
+
+  return SIGNAL_PHRASES.filter((phrase) => {
+    const normalizedPhrase = phrase.toLowerCase();
+    const pattern = normalizedPhrase.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/\s+/g, "\\s+");
+
+    return new RegExp(`\\b${pattern}\\b`, "i").test(lower);
+  }).map((phrase) => phrase.toLowerCase());
+}
+
+function getIgnoredTokens(job: Job) {
+  return new Set(tokenize([job.title, job.company].filter(Boolean).join(" ")));
+}
+
+function getRoleSignals(job: Job) {
+  const jobText = [job.sourceText, JSON.stringify(job.structuredSummary ?? "")]
+    .filter(Boolean)
+    .join(" ");
+  const ignoredTokens = getIgnoredTokens(job);
+  const phraseSignals = getSignalPhrases(jobText);
+  const tokenSignals = uniqueMeaningfulTokens(tokenize(jobText), ignoredTokens).filter(
+    (token) => !phraseSignals.some((phrase) => phrase.split(/\s+/).includes(token)),
+  );
+
+  return Array.from(new Set([...phraseSignals, ...tokenSignals])).slice(0, 8);
 }
 
 function getSenioritySignal(text: string) {
@@ -80,21 +172,20 @@ function getSenioritySignal(text: string) {
 
 function createMatchDetails(job: Job, resumeText: string, score: number) {
   const title = job.title?.trim() || "this role";
-  const jobTokens = uniqueMeaningfulTokens(
-    tokenize(
-      [job.title, job.company, job.sourceText, JSON.stringify(job.structuredSummary ?? "")]
-        .filter(Boolean)
-        .join(" "),
-    ),
-  );
+  const roleSignals = getRoleSignals(job);
+  const resumeSignalText = resumeText.toLowerCase();
   const resumeTokens = new Set(uniqueMeaningfulTokens(tokenize(resumeText)));
-  const matchedTerms = jobTokens.filter((token) => resumeTokens.has(token));
-  const missingTerms = jobTokens.filter((token) => !resumeTokens.has(token));
+  const matchedTerms = roleSignals.filter(
+    (term) => resumeSignalText.includes(term) || term.split(/\s+/).some((token) => resumeTokens.has(token)),
+  );
+  const missingTerms = roleSignals.filter((term) => !matchedTerms.includes(term));
   const strengths: string[] = [];
   const gaps: string[] = [];
 
   if (matchedTerms.length > 0) {
-    strengths.push(`Resume evidence overlaps with ${title}: ${formatTerms(matchedTerms)}.`);
+    strengths.push(
+      `Resume shows relevant evidence around ${formatTerms(matchedTerms, "the role")} for ${title}.`,
+    );
   }
 
   const seniority = getSenioritySignal([job.title, job.sourceText].filter(Boolean).join(" "));
@@ -105,26 +196,35 @@ function createMatchDetails(job: Job, resumeText: string, score: number) {
   }
 
   if (missingTerms.length > 0) {
-    gaps.push(`Resume evidence is thin for requested areas: ${formatTerms(missingTerms)}.`);
+    gaps.push(
+      `The application would be stronger with clearer evidence of ${formatTerms(
+        missingTerms,
+        "the core role requirements",
+      )}.`,
+    );
   }
 
   if (strengths.length === 0) {
-    strengths.push(`No strong resume overlap was found for ${title} in the current resume text.`);
+    strengths.push(`Resume evidence for ${title} is limited in the current resume text.`);
   }
 
   if (gaps.length === 0 && score > 0) {
-    gaps.push("No major keyword gaps were found in the current resume text.");
+    gaps.push("The main role signals are already represented clearly in the resume text.");
   }
 
   const reasons = [...strengths, ...gaps];
+  const recommendationFocus = formatTerms(
+    [...matchedTerms, ...missingTerms],
+    "the strongest role signals",
+  );
   const recommendation =
-    score >= 80
-      ? `Strong fit for ${title}. Prioritize this role and tailor the resume around the strongest matches.`
-      : score >= 60
-        ? `Good fit for ${title}. Worth applying with a tailored resume that reinforces the strongest overlaps.`
-        : score >= 40
-          ? `Moderate fit for ${title}. Consider applying if the role is interesting, but tailor carefully around the gaps.`
-          : `Weak fit for ${title}. Apply only if there is strong interest or missing resume context.`;
+    score >= 76
+      ? `Strong overlap detected. Prioritize ${title} and tailor the resume toward ${recommendationFocus}.`
+      : score >= 51
+        ? `Good overlap detected. Tailor the resume toward ${recommendationFocus} before applying.`
+        : score >= 26
+          ? `Moderate overlap detected. Tailoring the resume toward ${recommendationFocus} would strengthen the application.`
+          : `Weak overlap detected. Build clearer resume evidence around ${recommendationFocus} before prioritizing this role.`;
 
   return { strengths, gaps, reasons, recommendation };
 }

--- a/supabase/migrations/20260508000000_add_match_details_to_job_matches.sql
+++ b/supabase/migrations/20260508000000_add_match_details_to_job_matches.sql
@@ -1,0 +1,2 @@
+alter table public.job_matches
+  add column if not exists match_details jsonb;


### PR DESCRIPTION
## Summary

- Persist richer match analysis in `job_matches.match_details` from match, re-import, and backfill flows.
- Return persisted match details from `/api/jobs/ranked` when available, with graceful role-specific fallback details for legacy match rows.
- Add a per-job `Re-assess Fit` action that recalculates against the default/current resume, upserts the match result, and refreshes the ranked jobs list without changing job/import fields.
- Improve match-detail signal extraction and wording by filtering noisy business/culture terms, preferring technical/domain signals, and using coaching-style strengths, gaps, and recommendations.
- Recalibrate display labels/recommendations to Weak 0-25, Moderate 26-50, Good 51-75, Strong 76-100 while preserving the existing fit score calculation and sorting behavior.
- Fix the job Actions menu clipping by rendering it above table/details containers and flipping it upward when viewport space below is constrained.
- Add the additive `match_details jsonb` migration with `if not exists` so DEV/PRD can apply it safely before the ranked API selects the column.

## Test plan

- `pnpm --dir apps/job-coach-web test src/app/api/jobs/ranked/route.test.ts src/app/api/match/route.test.ts src/app/jobs/jobs-page-client.test.tsx src/server/match/calculate-fit.test.ts src/server/jobs/reimport-job.test.ts src/server/match/backfill-job-matches.test.ts`
- `pnpm --dir apps/job-coach-web typecheck`

## Manual validation

- Jobs page loads and ranked jobs render.
- Re-assess Fit updates a previously unmatched job with a persisted score and Match Details.
- Match Details uses improved coaching-style wording and avoids generic keyword-overlap phrasing.
- Actions dropdown remains visible near the bottom of the table and flips upward when needed.
- Import and re-import flows continue to work without changing job status unexpectedly.

Closes #160