### PR TITLE
Issue #126: Jobs: Recalculate match scores when resume changes

### DIFF
--- a/apps/job-coach-web/src/app/api/resume-profiles/[id]/tailored-resumes/route.test.ts
+++ b/apps/job-coach-web/src/app/api/resume-profiles/[id]/tailored-resumes/route.test.ts
@@ -35,7 +35,11 @@ describe("POST /api/resume-profiles/[id]/tailored-resumes", () => {
   it("creates a tailored resume version", async () => {
     const db = {};
     createServerClientMock.mockReturnValue(db);
-    backfillJobMatchesMock.mockResolvedValue({ updated: 2, resumeProfileId: "profile-2" });
+    backfillJobMatchesMock.mockResolvedValue({
+      updated: 2,
+      resumeProfileId: "profile-1",
+      resumeVersionId: "version-2",
+    });
     createTailoredResume.mockResolvedValue({
       version: {
         id: "version-2",
@@ -133,12 +137,16 @@ describe("POST /api/resume-profiles/[id]/tailored-resumes", () => {
         suggestions: expect.any(Array),
         matchRefresh: {
           updated: 2,
-          resumeProfileId: "profile-2",
+          resumeProfileId: "profile-1",
+          resumeVersionId: "version-2",
         },
       }),
     );
     expect(createServerClientMock).toHaveBeenCalledTimes(1);
-    expect(backfillJobMatchesMock).toHaveBeenCalledWith(db);
+    expect(backfillJobMatchesMock).toHaveBeenCalledWith(db, {
+      resumeProfileId: "profile-1",
+      resumeVersionId: "version-2",
+    });
   });
 
   it("returns 400 for invalid input", async () => {

--- a/apps/job-coach-web/src/app/api/resume-profiles/[id]/tailored-resumes/route.test.ts
+++ b/apps/job-coach-web/src/app/api/resume-profiles/[id]/tailored-resumes/route.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const createTailoredResume = vi.fn();
+const { createServerClientMock, backfillJobMatchesMock } = vi.hoisted(() => ({
+  createServerClientMock: vi.fn(),
+  backfillJobMatchesMock: vi.fn(),
+}));
 
 vi.mock("@/server/resume-tailoring/create-tailored-resume-service", () => {
   return {
@@ -8,12 +12,30 @@ vi.mock("@/server/resume-tailoring/create-tailored-resume-service", () => {
   };
 });
 
+vi.mock("@coach/db", async () => {
+  const actual = await vi.importActual<typeof import("@coach/db")>("@coach/db");
+
+  return {
+    ...actual,
+    createServerClient: createServerClientMock,
+  };
+});
+
+vi.mock("@/server/match/backfill-job-matches", () => ({
+  backfillJobMatches: backfillJobMatchesMock,
+}));
+
 describe("POST /api/resume-profiles/[id]/tailored-resumes", () => {
   beforeEach(() => {
     createTailoredResume.mockReset();
+    createServerClientMock.mockReset();
+    backfillJobMatchesMock.mockReset();
   });
 
   it("creates a tailored resume version", async () => {
+    const db = {};
+    createServerClientMock.mockReturnValue(db);
+    backfillJobMatchesMock.mockResolvedValue({ updated: 2, resumeProfileId: "profile-2" });
     createTailoredResume.mockResolvedValue({
       version: {
         id: "version-2",
@@ -109,8 +131,14 @@ describe("POST /api/resume-profiles/[id]/tailored-resumes", () => {
           versionId: "version-2",
         },
         suggestions: expect.any(Array),
+        matchRefresh: {
+          updated: 2,
+          resumeProfileId: "profile-2",
+        },
       }),
     );
+    expect(createServerClientMock).toHaveBeenCalledTimes(1);
+    expect(backfillJobMatchesMock).toHaveBeenCalledWith(db);
   });
 
   it("returns 400 for invalid input", async () => {

--- a/apps/job-coach-web/src/app/api/resume-profiles/[id]/tailored-resumes/route.ts
+++ b/apps/job-coach-web/src/app/api/resume-profiles/[id]/tailored-resumes/route.ts
@@ -1,4 +1,6 @@
 import { createTailoredResumeService } from "@/server/resume-tailoring/create-tailored-resume-service";
+import { createServerClient } from "@coach/db";
+import { backfillJobMatches } from "@/server/match/backfill-job-matches";
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
@@ -26,8 +28,9 @@ export async function POST(
       jobId: body.jobId,
       sourceResumeVersionId: body.sourceResumeVersionId,
     });
+    const matchRefresh = await backfillJobMatches(createServerClient());
 
-    return Response.json(result);
+    return Response.json({ ...result, matchRefresh });
   } catch (error) {
     if (
       error instanceof Error &&

--- a/apps/job-coach-web/src/app/api/resume-profiles/[id]/tailored-resumes/route.ts
+++ b/apps/job-coach-web/src/app/api/resume-profiles/[id]/tailored-resumes/route.ts
@@ -28,7 +28,10 @@ export async function POST(
       jobId: body.jobId,
       sourceResumeVersionId: body.sourceResumeVersionId,
     });
-    const matchRefresh = await backfillJobMatches(createServerClient());
+    const matchRefresh = await backfillJobMatches(createServerClient(), {
+      resumeProfileId,
+      resumeVersionId: result.version.id,
+    });
 
     return Response.json({ ...result, matchRefresh });
   } catch (error) {

--- a/apps/job-coach-web/src/app/api/resume-profiles/route.test.ts
+++ b/apps/job-coach-web/src/app/api/resume-profiles/route.test.ts
@@ -3,6 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const { createServerClientMock } = vi.hoisted(() => ({
   createServerClientMock: vi.fn(),
 }));
+const { backfillJobMatchesMock } = vi.hoisted(() => ({
+  backfillJobMatchesMock: vi.fn(),
+}));
 
 vi.mock("@coach/db", async () => {
   const actual = await vi.importActual<typeof import("@coach/db")>("@coach/db");
@@ -12,6 +15,10 @@ vi.mock("@coach/db", async () => {
     createServerClient: createServerClientMock,
   };
 });
+
+vi.mock("@/server/match/backfill-job-matches", () => ({
+  backfillJobMatches: backfillJobMatchesMock,
+}));
 
 function createPostDbMock() {
   const operations: Array<{ table: string; op: string; payload?: unknown }> = [];
@@ -168,6 +175,7 @@ describe("GET /api/resume-profiles", () => {
 describe("POST /api/resume-profiles", () => {
   beforeEach(() => {
     createServerClientMock.mockReset();
+    backfillJobMatchesMock.mockReset();
   });
 
   it("creates a resume profile and linked version", async () => {
@@ -183,6 +191,7 @@ describe("POST /api/resume-profiles", () => {
     };
     const { db, operations } = createPostDbMock();
     createServerClientMock.mockReturnValue(db);
+    backfillJobMatchesMock.mockResolvedValue({ updated: 3, resumeProfileId: "profile-123" });
     const { POST } = await import("./route");
 
     const response = await POST(
@@ -230,6 +239,7 @@ describe("POST /api/resume-profiles", () => {
         },
       },
     ]);
+    expect(backfillJobMatchesMock).toHaveBeenCalledWith(db);
     expect(await response.json()).toEqual({
       profile: {
         id: "profile-123",
@@ -240,6 +250,10 @@ describe("POST /api/resume-profiles", () => {
         id: "version-123",
         resume_profile_id: "profile-123",
         normalized_resume: { rawText: "Ian Handley" },
+      },
+      matchRefresh: {
+        updated: 3,
+        resumeProfileId: "profile-123",
       },
     });
   });

--- a/apps/job-coach-web/src/app/api/resume-profiles/route.test.ts
+++ b/apps/job-coach-web/src/app/api/resume-profiles/route.test.ts
@@ -191,7 +191,11 @@ describe("POST /api/resume-profiles", () => {
     };
     const { db, operations } = createPostDbMock();
     createServerClientMock.mockReturnValue(db);
-    backfillJobMatchesMock.mockResolvedValue({ updated: 3, resumeProfileId: "profile-123" });
+    backfillJobMatchesMock.mockResolvedValue({
+      updated: 3,
+      resumeProfileId: "profile-123",
+      resumeVersionId: "version-123",
+    });
     const { POST } = await import("./route");
 
     const response = await POST(
@@ -239,7 +243,10 @@ describe("POST /api/resume-profiles", () => {
         },
       },
     ]);
-    expect(backfillJobMatchesMock).toHaveBeenCalledWith(db);
+    expect(backfillJobMatchesMock).toHaveBeenCalledWith(db, {
+      resumeProfileId: "profile-123",
+      resumeVersionId: "version-123",
+    });
     expect(await response.json()).toEqual({
       profile: {
         id: "profile-123",
@@ -254,6 +261,7 @@ describe("POST /api/resume-profiles", () => {
       matchRefresh: {
         updated: 3,
         resumeProfileId: "profile-123",
+        resumeVersionId: "version-123",
       },
     });
   });

--- a/apps/job-coach-web/src/app/api/resume-profiles/route.ts
+++ b/apps/job-coach-web/src/app/api/resume-profiles/route.ts
@@ -138,7 +138,10 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: updateError.message }, { status: 500 });
   }
 
-  const matchRefresh = await backfillJobMatches(db);
+  const matchRefresh = await backfillJobMatches(db, {
+    resumeProfileId: profile.id,
+    resumeVersionId: version.id,
+  });
 
   return NextResponse.json({ profile: updatedProfile, version, matchRefresh }, { status: 201 });
 }

--- a/apps/job-coach-web/src/app/api/resume-profiles/route.ts
+++ b/apps/job-coach-web/src/app/api/resume-profiles/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createServerClient } from "@coach/db";
+import { backfillJobMatches } from "@/server/match/backfill-job-matches";
 
 export async function GET() {
   const db = createServerClient();
@@ -137,5 +138,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: updateError.message }, { status: 500 });
   }
 
-  return NextResponse.json({ profile: updatedProfile, version }, { status: 201 });
+  const matchRefresh = await backfillJobMatches(db);
+
+  return NextResponse.json({ profile: updatedProfile, version, matchRefresh }, { status: 201 });
 }

--- a/apps/job-coach-web/src/server/match/backfill-job-matches.test.ts
+++ b/apps/job-coach-web/src/server/match/backfill-job-matches.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { backfillJobMatches } from "./backfill-job-matches";
+import { normalizedResumeToText } from "./normalized-resume-to-text";
+
+const { normalizedResumeToTextMock } = vi.hoisted(() => ({
+  normalizedResumeToTextMock: vi.fn(),
+}));
 
 const jobs = [
   {
@@ -26,11 +31,16 @@ vi.mock("@coach/db", () => {
   };
 });
 
-vi.mock("@/server/resume/normalized-resume-to-text", () => ({
-  normalizedResumeToText: vi.fn(() => "TypeScript React leadership backend platform"),
+vi.mock("./normalized-resume-to-text", () => ({
+  normalizedResumeToText: normalizedResumeToTextMock,
 }));
 
 describe("backfillJobMatches", () => {
+  beforeEach(() => {
+    normalizedResumeToTextMock.mockReset();
+    normalizedResumeToTextMock.mockReturnValue("TypeScript React leadership backend platform");
+  });
+
   it("calculates and upserts a match row for every job", async () => {
     const upsert = vi.fn().mockResolvedValue({ error: null });
 
@@ -45,6 +55,7 @@ describe("backfillJobMatches", () => {
               data: {
                 id: "profile-1",
                 normalized_resume: { summary: "resume" },
+                current_version_id: null,
                 created_at: "2026-01-01T00:00:00.000Z",
               },
               error: null,
@@ -62,7 +73,7 @@ describe("backfillJobMatches", () => {
 
     const result = await backfillJobMatches(db);
 
-    expect(result).toEqual({ updated: 2, resumeProfileId: "profile-1" });
+    expect(result).toEqual({ updated: 2, resumeProfileId: "profile-1", resumeVersionId: null });
     expect(upsert).toHaveBeenCalledTimes(1);
 
     const rows = upsert.mock.calls[0][0];
@@ -82,8 +93,15 @@ describe("backfillJobMatches", () => {
     expect(typeof rows[1].score).toBe("number");
   });
 
-  it("falls back to latest resume version when the profile has no normalized resume", async () => {
+  it("uses the profile current resume version before the baseline profile resume", async () => {
     const upsert = vi.fn().mockResolvedValue({ error: null });
+    normalizedResumeToTextMock.mockImplementation((resume) => {
+      if ((resume as { summary?: string }).summary === "tailored resume") {
+        return "TypeScript React leadership backend platform";
+      }
+
+      return "Figma brand illustration";
+    });
 
     const db = {
       from: vi.fn((table: string) => {
@@ -95,7 +113,8 @@ describe("backfillJobMatches", () => {
             maybeSingle: vi.fn().mockResolvedValue({
               data: {
                 id: "profile-2",
-                normalized_resume: null,
+                normalized_resume: { summary: "baseline profile resume" },
+                current_version_id: "version-current",
                 created_at: "2026-01-01T00:00:00.000Z",
               },
               error: null,
@@ -107,11 +126,11 @@ describe("backfillJobMatches", () => {
           return {
             select: vi.fn().mockReturnThis(),
             eq: vi.fn().mockReturnThis(),
-            order: vi.fn().mockReturnThis(),
-            limit: vi.fn().mockReturnThis(),
             maybeSingle: vi.fn().mockResolvedValue({
               data: {
-                normalized_resume: { summary: "version resume" },
+                id: "version-current",
+                resume_profile_id: "profile-2",
+                normalized_resume: { summary: "tailored resume" },
                 created_at: "2026-01-02T00:00:00.000Z",
               },
               error: null,
@@ -129,8 +148,58 @@ describe("backfillJobMatches", () => {
 
     const result = await backfillJobMatches(db);
 
-    expect(result).toEqual({ updated: 2, resumeProfileId: "profile-2" });
+    expect(result).toEqual({
+      updated: 2,
+      resumeProfileId: "profile-2",
+      resumeVersionId: "version-current",
+    });
     expect(upsert).toHaveBeenCalledTimes(1);
+    expect(normalizedResumeToText).toHaveBeenCalledWith({ summary: "tailored resume" });
+    expect(normalizedResumeToText).not.toHaveBeenCalledWith({
+      summary: "baseline profile resume",
+    });
+  });
+
+  it("uses an explicit resume version when provided", async () => {
+    const upsert = vi.fn().mockResolvedValue({ error: null });
+
+    const db = {
+      from: vi.fn((table: string) => {
+        if (table === "resume_versions") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: {
+                id: "version-tailored",
+                resume_profile_id: "profile-tailored",
+                normalized_resume: { summary: "explicit tailored resume" },
+                created_at: "2026-01-02T00:00:00.000Z",
+              },
+              error: null,
+            }),
+          };
+        }
+
+        if (table === "job_matches") {
+          return { upsert };
+        }
+
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as any;
+
+    const result = await backfillJobMatches(db, {
+      resumeProfileId: "profile-tailored",
+      resumeVersionId: "version-tailored",
+    });
+
+    expect(result).toEqual({
+      updated: 2,
+      resumeProfileId: "profile-tailored",
+      resumeVersionId: "version-tailored",
+    });
+    expect(normalizedResumeToText).toHaveBeenCalledWith({ summary: "explicit tailored resume" });
   });
 
   it("calculates matches with empty resume text when no resume profile exists", async () => {
@@ -160,7 +229,7 @@ describe("backfillJobMatches", () => {
 
     const result = await backfillJobMatches(db);
 
-    expect(result).toEqual({ updated: 2, resumeProfileId: null });
+    expect(result).toEqual({ updated: 2, resumeProfileId: null, resumeVersionId: null });
     expect(upsert.mock.calls[0][0]).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -169,5 +238,42 @@ describe("backfillJobMatches", () => {
         }),
       ]),
     );
+  });
+
+  it("calculates matches with empty resume text when an explicit resume version is missing", async () => {
+    const upsert = vi.fn().mockResolvedValue({ error: null });
+
+    const db = {
+      from: vi.fn((table: string) => {
+        if (table === "resume_versions") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: null,
+              error: null,
+            }),
+          };
+        }
+
+        if (table === "job_matches") {
+          return { upsert };
+        }
+
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as any;
+
+    const result = await backfillJobMatches(db, {
+      resumeProfileId: "profile-missing-version",
+      resumeVersionId: "missing-version",
+    });
+
+    expect(result).toEqual({
+      updated: 2,
+      resumeProfileId: "profile-missing-version",
+      resumeVersionId: null,
+    });
+    expect(upsert).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/job-coach-web/src/server/match/backfill-job-matches.test.ts
+++ b/apps/job-coach-web/src/server/match/backfill-job-matches.test.ts
@@ -132,4 +132,42 @@ describe("backfillJobMatches", () => {
     expect(result).toEqual({ updated: 2, resumeProfileId: "profile-2" });
     expect(upsert).toHaveBeenCalledTimes(1);
   });
+
+  it("calculates matches with empty resume text when no resume profile exists", async () => {
+    const upsert = vi.fn().mockResolvedValue({ error: null });
+
+    const db = {
+      from: vi.fn((table: string) => {
+        if (table === "resume_profiles") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            order: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: null,
+              error: null,
+            }),
+          };
+        }
+
+        if (table === "job_matches") {
+          return { upsert };
+        }
+
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as any;
+
+    const result = await backfillJobMatches(db);
+
+    expect(result).toEqual({ updated: 2, resumeProfileId: null });
+    expect(upsert.mock.calls[0][0]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          job_id: "job-1",
+          resume_profile_id: null,
+        }),
+      ]),
+    );
+  });
 });

--- a/apps/job-coach-web/src/server/match/backfill-job-matches.ts
+++ b/apps/job-coach-web/src/server/match/backfill-job-matches.ts
@@ -6,18 +6,64 @@ import { normalizedResumeToText } from "./normalized-resume-to-text";
 type ResumeProfile = {
   id: string;
   normalized_resume: unknown | null;
+  current_version_id: string | null;
   created_at: string;
 };
 
 type ResumeVersion = {
+  id: string;
+  resume_profile_id: string;
   normalized_resume: unknown | null;
   created_at: string;
 };
 
-async function getLatestResumeText(db: SupabaseClient) {
-  const { data: profile, error: profileError } = await db
+type BackfillJobMatchesOptions = {
+  resumeProfileId?: string | null;
+  resumeVersionId?: string | null;
+};
+
+async function getResumeVersionText(db: SupabaseClient, resumeVersionId: string) {
+  const { data: version, error } = await db
+    .from("resume_versions")
+    .select("id, resume_profile_id, normalized_resume, created_at")
+    .eq("id", resumeVersionId)
+    .maybeSingle<ResumeVersion>();
+
+  if (error) throw error;
+
+  return version
+    ? {
+        resumeProfileId: version.resume_profile_id,
+        resumeVersionId: version.id,
+        resumeText: version.normalized_resume
+          ? normalizedResumeToText(version.normalized_resume)
+          : "",
+      }
+    : null;
+}
+
+async function getResumeText(db: SupabaseClient, options: BackfillJobMatchesOptions = {}) {
+  if (options.resumeVersionId) {
+    const version = await getResumeVersionText(db, options.resumeVersionId);
+
+    return (
+      version ?? {
+        resumeProfileId: options.resumeProfileId ?? null,
+        resumeVersionId: null,
+        resumeText: "",
+      }
+    );
+  }
+
+  let profileQuery = db
     .from("resume_profiles")
-    .select("id, normalized_resume, created_at")
+    .select("id, normalized_resume, current_version_id, created_at");
+
+  if (options.resumeProfileId) {
+    profileQuery = profileQuery.eq("id", options.resumeProfileId);
+  }
+
+  const { data: profile, error: profileError } = await profileQuery
     .order("created_at", { ascending: false })
     .limit(1)
     .maybeSingle<ResumeProfile>();
@@ -25,19 +71,32 @@ async function getLatestResumeText(db: SupabaseClient) {
   if (profileError) throw profileError;
 
   if (!profile) {
-    return { resumeProfileId: null, resumeText: "" };
+    return {
+      resumeProfileId: options.resumeProfileId ?? null,
+      resumeVersionId: null,
+      resumeText: "",
+    };
+  }
+
+  if (profile.current_version_id) {
+    const version = await getResumeVersionText(db, profile.current_version_id);
+
+    if (version) {
+      return version;
+    }
   }
 
   if (profile.normalized_resume) {
     return {
       resumeProfileId: profile.id,
+      resumeVersionId: null,
       resumeText: normalizedResumeToText(profile.normalized_resume),
     };
   }
 
   const { data: version, error: versionError } = await db
     .from("resume_versions")
-    .select("normalized_resume, created_at")
+    .select("id, resume_profile_id, normalized_resume, created_at")
     .eq("resume_profile_id", profile.id)
     .order("created_at", { ascending: false })
     .limit(1)
@@ -47,14 +106,18 @@ async function getLatestResumeText(db: SupabaseClient) {
 
   return {
     resumeProfileId: profile.id,
+    resumeVersionId: version?.id ?? null,
     resumeText: version?.normalized_resume ? normalizedResumeToText(version.normalized_resume) : "",
   };
 }
 
-export async function backfillJobMatches(db: SupabaseClient) {
+export async function backfillJobMatches(
+  db: SupabaseClient,
+  options: BackfillJobMatchesOptions = {},
+) {
   const jobRepo = new DbJobRepository(db);
   const jobs = await jobRepo.listJobs();
-  const { resumeProfileId, resumeText } = await getLatestResumeText(db);
+  const { resumeProfileId, resumeVersionId, resumeText } = await getResumeText(db, options);
 
   const rows = jobs.map((job: any) => {
     const result = calculateFit(job, { rawText: resumeText });
@@ -69,12 +132,12 @@ export async function backfillJobMatches(db: SupabaseClient) {
   });
 
   if (rows.length === 0) {
-    return { updated: 0, resumeProfileId };
+    return { updated: 0, resumeProfileId, resumeVersionId };
   }
 
   const { error } = await db.from("job_matches").upsert(rows);
 
   if (error) throw error;
 
-  return { updated: rows.length, resumeProfileId };
+  return { updated: rows.length, resumeProfileId, resumeVersionId };
 }

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -63,9 +63,10 @@ Typical responsibilities:
 - reasoning
 - chronological history
 
-Persisted job match rows are refreshed after a resume profile is created or the
-current resume version changes, so `/api/jobs/ranked` reflects the latest active
-resume without requiring a manual backfill call.
+Persisted job match rows are refreshed against the active/current resume version
+after a resume profile is created or the current resume version changes, so
+`/api/jobs/ranked` reflects the latest active resume without requiring a manual
+backfill call.
 
 ### Exported artifacts
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -63,6 +63,10 @@ Typical responsibilities:
 - reasoning
 - chronological history
 
+Persisted job match rows are refreshed after a resume profile is created or the
+current resume version changes, so `/api/jobs/ranked` reflects the latest active
+resume without requiring a manual backfill call.
+
 ### Exported artifacts
 
 Represents generated files such as:


### PR DESCRIPTION
## Summary
- Refresh persisted job matches after resume profile creation using the profile/version that was just created.
- Refresh persisted job matches after tailored resume creation using the newly current tailored resume version, not the baseline profile resume.
- Extend the shared backfill helper to accept explicit resumeProfileId/resumeVersionId and prefer current resume versions while preserving existing match_details output.
- Document that ranked jobs are refreshed from the active/current resume version.

## Targeted test plan
- `pnpm exec vitest run src/app/api/resume-profiles/route.test.ts 'src/app/api/resume-profiles/[id]/tailored-resumes/route.test.ts' src/server/match/backfill-job-matches.test.ts` from `apps/job-coach-web` - passed, 3 files / 14 tests.
- `pnpm --filter job-coach-web typecheck` - passed.
- `pnpm prettier --check apps/job-coach-web/src/server/match/backfill-job-matches.ts apps/job-coach-web/src/server/match/backfill-job-matches.test.ts apps/job-coach-web/src/app/api/resume-profiles/route.ts 'apps/job-coach-web/src/app/api/resume-profiles/[id]/tailored-resumes/route.ts' apps/job-coach-web/src/app/api/resume-profiles/route.test.ts 'apps/job-coach-web/src/app/api/resume-profiles/[id]/tailored-resumes/route.test.ts' docs/data-model.md` - passed.